### PR TITLE
Feature: Log to function if request.logger is a function and verbose == true

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -672,6 +672,13 @@ class Request extends EventEmitter
 	canceled: false
 	
 	###
+	Log to a function if assigned. Else, use console.log.
+	###
+
+	doLog: (out) ->
+		if @logger and typeof @logger == "function" then @logger out else console.log out
+
+	###
 	Create new Request.
 	
 	@param {Connection|Transaction} connection If ommited, global connection is used instead.

--- a/src/msnodesql.coffee
+++ b/src/msnodesql.coffee
@@ -193,15 +193,15 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 
 	class MsnodesqlRequest extends Request
 		query: (command, callback) ->
-			if @verbose and not @nested then console.log "---------- sql query ----------\n    query: #{command}"
+			if @verbose and not @nested then @doLog "---------- sql query ----------\n    query: #{command}"
 			
 			if command.length is 0
 				return process.nextTick ->
 					if @verbose and not @nested
-						console.log "---------- response -----------"
+						@doLog "---------- response -----------"
 						elapsed = Date.now() - started
-						console.log " duration: #{elapsed}ms"
-						console.log "---------- completed ----------"
+						@doLog " duration: #{elapsed}ms"
+						@doLog "---------- completed ----------"
 		
 					callback? null, if @multiple or @nested then [] else null
 			
@@ -226,13 +226,13 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 			@_acquire (err, connection) =>
 				unless err
 					req = connection.queryRaw command, (castParameter(param.value, param.type) for name, param of @parameters when param.io is 1)
-					if @verbose and not @nested then console.log "---------- response -----------"
+					if @verbose and not @nested then @doLog "---------- response -----------"
 					
 					req.on 'meta', (metadata) =>
 						if row
 							if @verbose
-								console.log util.inspect(row)
-								console.log "---------- --------------------"
+								@doLog util.inspect(row)
+								@doLog "---------- --------------------"
 
 							unless row["___return___"]?
 								# row with ___return___ col is the last row
@@ -253,8 +253,8 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 					req.on 'row', (rownumber) =>
 						if row
 							if @verbose
-								console.log util.inspect(row)
-								console.log "---------- --------------------"
+								@doLog util.inspect(row)
+								@doLog "---------- --------------------"
 
 							unless row["___return___"]?
 								# row with ___return___ col is the last row
@@ -280,9 +280,9 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 					req.once 'error', (err) =>
 						if @verbose and not @nested
 							elapsed = Date.now() - started
-							console.log "    error: #{err}"
-							console.log " duration: #{elapsed}ms"
-							console.log "---------- completed ----------"
+							@doLog "    error: #{err}"
+							@doLog " duration: #{elapsed}ms"
+							@doLog "---------- completed ----------"
 							
 						callback? RequestError err
 					
@@ -294,8 +294,8 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 								
 							if @verbose
 								if row
-									console.log util.inspect(row)
-									console.log "---------- --------------------"
+									@doLog util.inspect(row)
+									@doLog "---------- --------------------"
 		
 							# do we have output parameters to handle?
 							if handleOutput
@@ -305,12 +305,12 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 									param.value = last[param.name]
 				
 									if @verbose
-										console.log "   output: @#{param.name}, #{param.type.declaration}, #{param.value}"
+										@doLog "   output: @#{param.name}, #{param.type.declaration}, #{param.value}"
 							
 							if @verbose
 								elapsed = Date.now() - started
-								console.log " duration: #{elapsed}ms"
-								console.log "---------- completed ----------"
+								@doLog " duration: #{elapsed}ms"
+								@doLog "---------- completed ----------"
 
 						@_release connection
 						callback? null, if @multiple or @nested then recordsets else recordsets[0]
@@ -320,7 +320,7 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 					callback? err
 	
 		execute: (procedure, callback) ->
-			if @verbose then console.log "---------- sql execute --------\n     proc: #{procedure}"
+			if @verbose then @doLog "---------- sql execute --------\n     proc: #{procedure}"
 	
 			started = Date.now()
 			
@@ -330,7 +330,7 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 			spp = []
 			for name, param of @parameters
 				if @verbose
-					console.log "   #{if param.io is 1 then " input" else "output"}: @#{param.name}, #{param.type.declaration}, #{param.value}"
+					@doLog "   #{if param.io is 1 then " input" else "output"}: @#{param.name}, #{param.type.declaration}, #{param.value}"
 						
 				if param.io is 2
 					# output parameter
@@ -342,7 +342,7 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 			cmd += "#{spp.join ', '};"
 			cmd += "select #{['@___return___ as \'___return___\''].concat("@#{param.name} as '#{param.name}'" for name, param of @parameters when param.io is 2).join ', '};"
 			
-			if @verbose then console.log "---------- response -----------"
+			if @verbose then @doLog "---------- response -----------"
 			
 			@nested = true
 			
@@ -353,9 +353,9 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 				if err
 					if @verbose
 						elapsed = Date.now() - started
-						console.log "    error: #{err}"
-						console.log " duration: #{elapsed}ms"
-						console.log "---------- completed ----------"
+						@doLog "    error: #{err}"
+						@doLog " duration: #{elapsed}ms"
+						@doLog "---------- completed ----------"
 					
 					callback? err
 				
@@ -368,13 +368,13 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 							param.value = last[param.name]
 		
 							if @verbose
-								console.log "   output: @#{param.name}, #{param.type.declaration}, #{param.value}"
+								@doLog "   output: @#{param.name}, #{param.type.declaration}, #{param.value}"
 		
 					if @verbose
 						elapsed = Date.now() - started
-						console.log "   return: #{returnValue}"
-						console.log " duration: #{elapsed}ms"
-						console.log "---------- completed ----------"
+						@doLog "   return: #{returnValue}"
+						@doLog " duration: #{elapsed}ms"
+						@doLog "---------- completed ----------"
 					
 					recordsets.returnValue = returnValue
 					callback? null, recordsets, returnValue

--- a/src/tds.coffee
+++ b/src/tds.coffee
@@ -226,15 +226,15 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 			
 	class TDSRequest extends Request
 		query: (command, callback) ->
-			if @verbose and not @nested then console.log "---------- sql query ----------\n    query: #{command}"
+			if @verbose and not @nested then @doLog "---------- sql query ----------\n    query: #{command}"
 			
 			if command.length is 0
 				return process.nextTick ->
 					if @verbose and not @nested
-						console.log "---------- response -----------"
+						@doLog "---------- response -----------"
 						elapsed = Date.now() - started
-						console.log " duration: #{elapsed}ms"
-						console.log "---------- completed ----------"
+						@doLog " duration: #{elapsed}ms"
+						@doLog "---------- completed ----------"
 		
 					callback? null, if @multiple or @nested then [] else null
 			
@@ -287,8 +287,8 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 								row[col.name] = value
 
 						if @verbose
-							console.log util.inspect(row)
-							console.log "---------- --------------------"
+							@doLog util.inspect(row)
+							@doLog "---------- --------------------"
 						
 						unless row["___return___"]?
 							# row with ___return___ col is the last row
@@ -324,13 +324,13 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 									param.value = last[param.name]
 				
 									if @verbose
-										console.log "   output: @#{param.name}, #{param.type.declaration}, #{param.value}"
+										@doLog "   output: @#{param.name}, #{param.type.declaration}, #{param.value}"
 						
 							if @verbose
-								if error then console.log "    error: #{error}"
+								if error then @doLog "    error: #{error}"
 								elapsed = Date.now() - started
-								console.log " duration: #{elapsed}ms"
-								console.log "---------- completed ----------"
+								@doLog " duration: #{elapsed}ms"
+								@doLog "---------- completed ----------"
 		
 						@_release connection
 						callback? error, if @multiple or @nested then recordsets else recordsets[0]
@@ -345,7 +345,7 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 					callback? err
 
 		execute: (procedure, callback) ->
-			if @verbose then console.log "---------- sql execute --------\n     proc: #{procedure}"
+			if @verbose then @doLog "---------- sql execute --------\n     proc: #{procedure}"
 	
 			started = Date.now()
 			
@@ -355,7 +355,7 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 			spp = []
 			for name, param of @parameters
 				if @verbose
-					console.log "   #{if param.io is 1 then " input" else "output"}: @#{param.name}, #{param.type.declaration}, #{param.value}"
+					@doLog "   #{if param.io is 1 then " input" else "output"}: @#{param.name}, #{param.type.declaration}, #{param.value}"
 						
 				if param.io is 2
 					# output parameter
@@ -367,7 +367,7 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 			cmd += "#{spp.join ', '};"
 			cmd += "select #{['@___return___ as \'___return___\''].concat("@#{param.name} as '#{param.name}'" for name, param of @parameters when param.io is 2).join ', '};"
 			
-			if @verbose then console.log "---------- response -----------"
+			if @verbose then @doLog "---------- response -----------"
 			
 			@nested = true
 			
@@ -378,9 +378,9 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 				if err
 					if @verbose
 						elapsed = Date.now() - started
-						console.log "    error: #{err}"
-						console.log " duration: #{elapsed}ms"
-						console.log "---------- completed ----------"
+						@doLog "    error: #{err}"
+						@doLog " duration: #{elapsed}ms"
+						@doLog "---------- completed ----------"
 					
 					callback? err
 				
@@ -393,13 +393,13 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 							param.value = last[param.name]
 		
 							if @verbose
-								console.log "   output: @#{param.name}, #{param.type.declaration}, #{param.value}"
+								@doLog "   output: @#{param.name}, #{param.type.declaration}, #{param.value}"
 		
 					if @verbose
 						elapsed = Date.now() - started
-						console.log "   return: #{returnValue}"
-						console.log " duration: #{elapsed}ms"
-						console.log "---------- completed ----------"
+						@doLog "   return: #{returnValue}"
+						@doLog " duration: #{elapsed}ms"
+						@doLog "---------- completed ----------"
 					
 					recordsets.returnValue = returnValue
 					callback? null, recordsets, returnValue

--- a/src/tedious.coffee
+++ b/src/tedious.coffee
@@ -185,7 +185,7 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 						if err then return callback err, null # there must be a second argument null
 						callback null, c
 					
-					#c.on 'debug', (msg) -> console.log msg
+					#c.on 'debug', (msg) -> @doLog msg
 
 				validate: (c) ->
 					c? and !c.closed
@@ -256,25 +256,25 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 
 			@_acquire (err, connection) =>
 				unless err
-					if @verbose then console.log "---------- sql query ----------\n    query: #{command}"
+					if @verbose then @doLog "---------- sql query ----------\n    query: #{command}"
 
 					if @canceled
-						if @verbose then console.log "---------- canceling ----------"
+						if @verbose then @doLog "---------- canceling ----------"
 						@_release connection
 						return callback? new RequestError "Canceled.", 'ECANCEL'
 					
 					@_cancel = =>
-						if @verbose then console.log "---------- canceling ----------"
+						if @verbose then @doLog "---------- canceling ----------"
 						connection.cancel()
 					
 					req = new tds.Request command, (err) =>
 						if err then err = RequestError err
 						
 						if @verbose 
-							if err then console.log "    error: #{err}"
+							if err then @doLog "    error: #{err}"
 							elapsed = Date.now() - started
-							console.log " duration: #{elapsed}ms"
-							console.log "---------- completed ----------"
+							@doLog " duration: #{elapsed}ms"
+							@doLog "---------- completed ----------"
 
 						if recordset
 							Object.defineProperty recordset, 'columns', 
@@ -312,9 +312,9 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 					req.on 'returnValue', (parameterName, value, metadata) =>
 						if @verbose
 							if value is tds.TYPES.Null
-								console.log "   output: @#{parameterName}, null"
+								@doLog "   output: @#{parameterName}, null"
 							else
-								console.log "   output: @#{parameterName}, #{@parameters[parameterName].type.declaration.toLowerCase()}, #{value}"
+								@doLog "   output: @#{parameterName}, #{@parameters[parameterName].type.declaration.toLowerCase()}, #{value}"
 								
 						@parameters[parameterName].value = if value is tds.TYPES.Null then null else value
 					
@@ -338,8 +338,8 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 								row[col.metadata.colName] = col.value
 						
 						if @verbose
-							console.log util.inspect(row)
-							console.log "---------- --------------------"
+							@doLog util.inspect(row)
+							@doLog "---------- --------------------"
 						
 						@emit 'row', row
 						
@@ -348,16 +348,16 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 					for name, param of @parameters when param.io is 1
 						if @verbose
 							if param.value is tds.TYPES.Null
-								console.log "    input: @#{param.name}, null"
+								@doLog "    input: @#{param.name}, null"
 							else
-								console.log "    input: @#{param.name}, #{param.type.declaration.toLowerCase()}, #{param.value}"
+								@doLog "    input: @#{param.name}, #{param.type.declaration.toLowerCase()}, #{param.value}"
 						
 						req.addParameter param.name, getTediousType(param.type), parameterCorrection(param.value), {length: param.length, scale: param.scale, precision: param.precision}
 					
 					for name, param of @parameters when param.io is 2
 						req.addOutputParameter param.name, getTediousType(param.type), parameterCorrection(param.value), {length: param.length, scale: param.scale, precision: param.precision}
 					
-					if @verbose then console.log "---------- response -----------"
+					if @verbose then @doLog "---------- response -----------"
 					connection.execSql req
 				
 				else
@@ -377,27 +377,27 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 
 			@_acquire (err, connection) =>
 				unless err
-					if @verbose then console.log "---------- sql execute --------\n     proc: #{procedure}"
+					if @verbose then @doLog "---------- sql execute --------\n     proc: #{procedure}"
 					
 					if @canceled
-						if @verbose then console.log "---------- canceling ----------"
+						if @verbose then @doLog "---------- canceling ----------"
 						@_release connection
 						return callback? new RequestError "Canceled.", 'ECANCEL'
 					
 					@_cancel = =>
-						if @verbose then console.log "---------- canceling ----------"
+						if @verbose then @doLog "---------- canceling ----------"
 						connection.cancel()
 					
 					req = new tds.Request procedure, (err) =>
 						if err then err = RequestError err
 						
 						if @verbose 
-							if err then console.log "    error: #{err}"
+							if err then @doLog "    error: #{err}"
 							
 							elapsed = Date.now() - started
-							console.log "   return: #{returnValue}"
-							console.log " duration: #{elapsed}ms"
-							console.log "---------- completed ----------"
+							@doLog "   return: #{returnValue}"
+							@doLog " duration: #{elapsed}ms"
+							@doLog "---------- completed ----------"
 						
 						@_cancel = null
 						@_release connection
@@ -429,8 +429,8 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 								row[col.metadata.colName] = col.value
 						
 						if @verbose
-							console.log util.inspect(row)
-							console.log "---------- --------------------"
+							@doLog util.inspect(row)
+							@doLog "---------- --------------------"
 						
 						@emit 'row', row
 						
@@ -465,25 +465,25 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 							
 						if @verbose
 							if value is tds.TYPES.Null
-								console.log "   output: @#{parameterName}, null"
+								@doLog "   output: @#{parameterName}, null"
 							else
-								console.log "   output: @#{parameterName}, #{@parameters[parameterName].type.declaration.toLowerCase()}, #{value}"
+								@doLog "   output: @#{parameterName}, #{@parameters[parameterName].type.declaration.toLowerCase()}, #{value}"
 								
 						@parameters[parameterName].value = if value is tds.TYPES.Null then null else value
 					
 					for name, param of @parameters
 						if @verbose
 							if param.value is tds.TYPES.Null
-								console.log "   #{if param.io is 1 then " input" else "output"}: @#{param.name}, null"
+								@doLog "   #{if param.io is 1 then " input" else "output"}: @#{param.name}, null"
 							else
-								console.log "   #{if param.io is 1 then " input" else "output"}: @#{param.name}, #{param.type.declaration.toLowerCase()}, #{param.value}"
+								@doLog "   #{if param.io is 1 then " input" else "output"}: @#{param.name}, #{param.type.declaration.toLowerCase()}, #{param.value}"
 						
 						if param.io is 1
 							req.addParameter param.name, getTediousType(param.type), parameterCorrection(param.value), {length: param.length, scale: param.scale, precision: param.precision}
 						else
 							req.addOutputParameter param.name, getTediousType(param.type), parameterCorrection(param.value), {length: param.length, scale: param.scale, precision: param.precision}
 
-					if @verbose then console.log "---------- response -----------"
+					if @verbose then @doLog "---------- response -----------"
 					connection.callProcedure req
 				
 				else


### PR DESCRIPTION
To log a SQL transaction using **node-mssql**, one typically sets `req.verbose = true`.

However, this is hardcoded to use `console.log()` which is not always appropriate.
This patch allows a user-defined function to be used instead.

``` coffeescript
req.verbose = true
req.logger = logger.debug
```

This assumes logger.debug is a function which takes a single argument.
