### PR TITLE
Version bump for tedious

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 .DS_Store
 .svn
 .coffeemaker
+.idea
 /lib/*.js
 /test/_connection.coffee

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		}
 	],
 	"dependencies": {
-		"tedious": "^1.4.0",
+		"tedious": "^1.5.3",
 		"generic-pool": "^2.0.4"
 	},
 	"devDependencies": {


### PR DESCRIPTION
SQL Browser operations in `tedious` had a hard-coded 2 second timeout. Now that it's fixed (see https://github.com/pekim/tedious/pull/196) and released as `v1.5.3`, I'd like to pull it into `mssql`.
