### PR TITLE
Fix issue #438

### DIFF
--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -40,11 +40,10 @@ const castParameter = function (value, type, param) {
       }
       // add excplicit type specication for Varchar, Char and NChar because msnodesql has some problems with strings
       // greatet than 2000
-      if(value.length > 2000 && (type === TYPES.VarChar || type === TYPES.NVarChar)) {
+      if (value.length > 2000 && (type === TYPES.VarChar || type === TYPES.NVarChar)) {
         return msnodesql.WLongVarChar(value)
-      }
-      else if(type === TYPES.Char) return msnodesql.Char(value)
-      else if(type === TYPES.NChar) return msnodesql.NChar(value)
+      } else if (type === TYPES.Char) return msnodesql.Char(value)
+      else if (type === TYPES.NChar) return msnodesql.NChar(value)
 
       break
 
@@ -93,7 +92,7 @@ const castParameter = function (value, type, param) {
       }
       break
   }
-  
+
   return value
 }
 

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -10,7 +10,6 @@ const UDT = require('./udt').PARSERS
 const DECLARATIONS = require('./datatypes').DECLARATIONS
 const ISOLATION_LEVEL = require('./isolationlevel')
 
-const MAX = 65535
 const EMPTY_BUFFER = new Buffer(0)
 const JSON_COLUMN_ID = 'JSON_F52E2B61-18A1-11d1-B105-00805F49916B'
 const XML_COLUMN_ID = 'XML_F52E2B61-18A1-11d1-B105-00805F49916B'
@@ -88,8 +87,8 @@ const castParameter = function (value, type, param) {
   }
 
   switch (type) {
-    case TYPES.VarChar: return msnodesql.VarChar(value)
-    case TYPES.NVarChar: return param.length === MAX ? msnodesql.WLongVarChar(value) : msnodesql.NVarChar(value)
+    case TYPES.VarChar: return value.length > 2000 ? msnodesql.WLongVarChar(value) : msnodesql.VarChar(value)
+    case TYPES.NVarChar: return value.length > 2000 ? msnodesql.WLongVarChar(value) : msnodesql.NVarChar(value)
     case TYPES.Text: return msnodesql.Text(value)
     case TYPES.Int: return msnodesql.Int(value)
     case TYPES.BigInt: return msnodesql.BigInt(value)
@@ -537,7 +536,9 @@ class Request extends base.Request {
 
             let exi = row[columns[idx].name]
             if (exi != null) {
-              if (exi instanceof Array) {
+              if (typeof exi === 'string' && typeof data === 'string' && columns[idx].type === 'text') {
+                row[columns[idx].name] += data.toString()
+              } else if (exi instanceof Array) {
                 exi.push(data)
               } else {
                 row[columns[idx].name] = [exi, data]

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -38,6 +38,14 @@ const castParameter = function (value, type, param) {
       if ((typeof value !== 'string') && !(value instanceof String)) {
         value = value.toString()
       }
+      // add excplicit type specication for Varchar, Char and NChar because msnodesql has some problems with strings
+      // greatet than 2000
+      if(value.length > 2000 && (type === TYPES.VarChar || type === TYPES.NVarChar)) {
+        return msnodesql.WLongVarChar(value)
+      }
+      else if(type === TYPES.Char) return msnodesql.Char(value)
+      else if(type === TYPES.NChar) return msnodesql.NChar(value)
+
       break
 
     case TYPES.Int:
@@ -85,41 +93,7 @@ const castParameter = function (value, type, param) {
       }
       break
   }
-
-  switch (type) {
-    case TYPES.VarChar: return value.length > 2000 ? msnodesql.WLongVarChar(value) : msnodesql.VarChar(value)
-    case TYPES.NVarChar: return value.length > 2000 ? msnodesql.WLongVarChar(value) : msnodesql.NVarChar(value)
-    case TYPES.Text: return msnodesql.Text(value)
-    case TYPES.Int: return msnodesql.Int(value)
-    case TYPES.BigInt: return msnodesql.BigInt(value)
-    case TYPES.TinyInt: return msnodesql.TinyInt(value)
-    case TYPES.SmallInt: return msnodesql.SmallInt(value)
-    case TYPES.Bit: return msnodesql.Bit(value)
-    case TYPES.Float: return msnodesql.Float(value)
-    case TYPES.Decimal: return msnodesql.Decimal(value)
-    case TYPES.Numeric: return msnodesql.Numeric(value)
-    case TYPES.Real: return msnodesql.Real(value)
-    case TYPES.Money: return msnodesql.Money(value)
-    case TYPES.SmallMoney: return msnodesql.SmallMoney(value)
-    case TYPES.Time: return msnodesql.Time(value)
-    case TYPES.Date: return msnodesql.Date(value)
-    case TYPES.DateTime: return msnodesql.DateTime(value)
-    case TYPES.DateTime2: return msnodesql.DateTime2(value)
-    case TYPES.DateTimeOffset: return msnodesql.DateTimeOffset(value)
-    case TYPES.SmallDateTime: return msnodesql.SmallDateTime(value)
-    case TYPES.UniqueIdentifier: return msnodesql.UniqueIdentifier(value)
-    case TYPES.Xml: return msnodesql.Xml(value)
-    case TYPES.Char: return msnodesql.Char(value)
-    case TYPES.NChar: return msnodesql.NChar(value)
-    case TYPES.NText: return msnodesql.NVarChar(value)
-    case TYPES.Image: return msnodesql.Image(value)
-    case TYPES.Binary: return msnodesql.VarBinary(value)
-    case TYPES.VarBinary: return msnodesql.VarBinary(value)
-    // case TYPES.UDT: case TYPES.Geography: case TYPES.Geometry: return msnodesql.UDT(value)
-    // case TYPES.TVP: return msnodesql.TVP(value)
-    // case TYPES.Variant: return msnodesql.Variant(value)
-  }
-
+  
   return value
 }
 

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -10,6 +10,7 @@ const UDT = require('./udt').PARSERS
 const DECLARATIONS = require('./datatypes').DECLARATIONS
 const ISOLATION_LEVEL = require('./isolationlevel')
 
+const MAX = 65535
 const EMPTY_BUFFER = new Buffer(0)
 const JSON_COLUMN_ID = 'JSON_F52E2B61-18A1-11d1-B105-00805F49916B'
 const XML_COLUMN_ID = 'XML_F52E2B61-18A1-11d1-B105-00805F49916B'
@@ -17,7 +18,7 @@ const XML_COLUMN_ID = 'XML_F52E2B61-18A1-11d1-B105-00805F49916B'
 const CONNECTION_STRING_PORT = 'Driver={SQL Server Native Client 11.0};Server={#{server},#{port}};Database={#{database}};Uid={#{user}};Pwd={#{password}};Trusted_Connection={#{trusted}};'
 const CONNECTION_STRING_NAMED_INSTANCE = 'Driver={SQL Server Native Client 11.0};Server={#{server}\\#{instance}};Database={#{database}};Uid={#{user}};Pwd={#{password}};Trusted_Connection={#{trusted}};'
 
-const castParameter = function (value, type) {
+const castParameter = function (value, type, param) {
   if (value == null) {
     if ((type === TYPES.Binary) || (type === TYPES.VarBinary) || (type === TYPES.Image)) {
       // msnodesql has some problems with NULL values in those types, so we need to replace it with empty buffer
@@ -84,6 +85,40 @@ const castParameter = function (value, type) {
         value = new Buffer(value.toString())
       }
       break
+  }
+
+  switch (type) {
+    case TYPES.VarChar: return msnodesql.VarChar(value)
+    case TYPES.NVarChar: return param.length === MAX ? msnodesql.WLongVarChar(value) : msnodesql.NVarChar(value)
+    case TYPES.Text: return msnodesql.Text(value)
+    case TYPES.Int: return msnodesql.Int(value)
+    case TYPES.BigInt: return msnodesql.BigInt(value)
+    case TYPES.TinyInt: return msnodesql.TinyInt(value)
+    case TYPES.SmallInt: return msnodesql.SmallInt(value)
+    case TYPES.Bit: return msnodesql.Bit(value)
+    case TYPES.Float: return msnodesql.Float(value)
+    case TYPES.Decimal: return msnodesql.Decimal(value)
+    case TYPES.Numeric: return msnodesql.Numeric(value)
+    case TYPES.Real: return msnodesql.Real(value)
+    case TYPES.Money: return msnodesql.Money(value)
+    case TYPES.SmallMoney: return msnodesql.SmallMoney(value)
+    case TYPES.Time: return msnodesql.Time(value)
+    case TYPES.Date: return msnodesql.Date(value)
+    case TYPES.DateTime: return msnodesql.DateTime(value)
+    case TYPES.DateTime2: return msnodesql.DateTime2(value)
+    case TYPES.DateTimeOffset: return msnodesql.DateTimeOffset(value)
+    case TYPES.SmallDateTime: return msnodesql.SmallDateTime(value)
+    case TYPES.UniqueIdentifier: return msnodesql.UniqueIdentifier(value)
+    case TYPES.Xml: return msnodesql.Xml(value)
+    case TYPES.Char: return msnodesql.Char(value)
+    case TYPES.NChar: return msnodesql.NChar(value)
+    case TYPES.NText: return msnodesql.NVarChar(value)
+    case TYPES.Image: return msnodesql.Image(value)
+    case TYPES.Binary: return msnodesql.VarBinary(value)
+    case TYPES.VarBinary: return msnodesql.VarBinary(value)
+    // case TYPES.UDT: case TYPES.Geography: case TYPES.Geometry: return msnodesql.UDT(value)
+    // case TYPES.TVP: return msnodesql.TVP(value)
+    // case TYPES.Variant: return msnodesql.Variant(value)
   }
 
   return value

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -398,15 +398,17 @@ module.exports = (sql, driver) => {
 
       req.input('vch', sql.NVarChar(sql.MAX), bigStr)
       req.input('nvch', sql.VarChar(sql.MAX), bigStr)
+      req.input('xml', sql.XML, bigStr)
       req.input('vch2', sql.VarChar, bigStr)
       req.input('nch', sql.NChar(3500), ncharBigStr)
       req.input('ch', sql.Char(7000), charBigStr)
 
-      req[mode]('select @vch as vch, @nvch as nvch, @vch2 as vch2, @nch as nch, @ch as ch').then(result => {
+      req[mode]('select @vch as vch, @nvch as nvch, @vch2 as vch2, @nch as nch, @ch as ch, @xml as xml').then(result => {
         assert.equal(result.recordset.length, 1)
         assert.equal(result.recordset[0].vch, bigStr)
         assert.equal(result.recordset[0].nvch, bigStr)
         assert.equal(result.recordset[0].vch2, bigStr)
+        assert.equal(result.recordset[0].xml, bigStr)
         assert.equal(result.recordset[0].nch, ncharBigStr)
         assert.equal(result.recordset[0].ch, charBigStr)
 

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -53,6 +53,7 @@ describe('msnodesqlv8', function () {
     it('query with multiple recordsets', done => TESTS['query with multiple recordsets'](done))
     it('query with input parameters', done => TESTS['query with input parameters']('query', done))
     it('query with input parameters (batch)', done => TESTS['query with input parameters']('batch', done))
+    it('query with big strings', done => TESTS['query with big strings']('query', done))
     it('query with output parameters', done => TESTS['query with output parameters']('query', done))
     it('query with output parameters (batch)', done => TESTS['query with output parameters']('batch', done))
     it('query with error', done => TESTS['query with error'](done))


### PR DESCRIPTION
Ok, it seems to work now :) Here is my fix for the issue #438.

I hope the way i fixed it is ok for you. I had to do a string-concat inside the column-event because the hole string was returned as an array of strings, each with a length of 8000. So i thought it makes sense to directly combine them before returning.

I also added tests for Char & NChar, but it i think these two types were aleready working before...
But concerning the specs on the [microsoft docs](https://docs.microsoft.com/en-us/sql/t-sql/data-types/char-and-varchar-transact-sql) they anyway have a limitation to (8000 for char and 4000 for nchar).

For Text and NText i didn't see any need, because they are not accepted as input params...

Thank you for creating this awesome library :)