### PR TITLE
Fixed instructions regarding SQL Server Browser (port 1434)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Default driver, actively maintained and production ready. Platform independent, 
 
 **Extra options:**
 
-- **options.instanceName** - The instance name to connect to. The SQL Server Browser service must be running on the database server, and UDP port 1444 on the database server must be reachable.
+- **options.instanceName** - The instance name to connect to. The SQL Server Browser service must be running on the database server, and UDP port 1434 on the database server must be reachable.
 - **options.useUTC** - A boolean determining whether or not use UTC time for values without time zone offset (default: `true`).
 - **options.encrypt** - A boolean determining whether or not the connection will be encrypted (default: `false`).
 - **options.tdsVersion** - The version of TDS to use (default: `7_4`, available: `7_1`, `7_2`, `7_3_A`, `7_3_B`, `7_4`).


### PR DESCRIPTION
Currently it is stated that the UDP port **1444** should be reachable in order to request info from SQL Server Browser, however, the port used by Tedious is **1434**.

From: tedious/lib/instance-lookup.js
```javascript
15.  var SQL_SERVER_BROWSER_PORT = 1434;
16.  var TIMEOUT = 2 * 1000;
17.  var RETRIES = 3;
````