### PR TITLE
fix error unexisting connection-object pool

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -193,9 +193,10 @@ class ConnectionPool extends EventEmitter {
 
   release (connection) {
     debug('conn: release')
-
-    this.pool.release(connection)
-    return this
+    if (this.pool) {
+      this.pool.release(connection)  
+    }
+    return this    
   }
 
   /**

--- a/lib/base.js
+++ b/lib/base.js
@@ -194,9 +194,9 @@ class ConnectionPool extends EventEmitter {
   release (connection) {
     debug('conn: release')
     if (this.pool) {
-      this.pool.release(connection)  
+      this.pool.release(connection)
     }
-    return this    
+    return this
   }
 
   /**


### PR DESCRIPTION
IF i use ES6 style promises

const sql = require('mssql')

sql.connect(config).then(() => {

query1 = sql.query`select * from mytable where id = ${value}`
query2 = sql.query`select * from mytable where id = ${value}`
return Promise.all([ query1, query2 ]).then(dataset => {
  return dataset;
});
}).then(result => {
console.dir(result)
}).catch(err => {
// ... error checks
})

and if one of requests fails (by timeout for example), application gets critical error "can't find property release of null (pool.release)"