### PR TITLE
Add support for passing array to tagged template litteral

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -999,8 +999,17 @@ class Request extends EventEmitter {
 
     for (let index = 0; index < values.length; index++) {
       let value = values[index]
-      this.input(`param${index + 1}`, value)
-      command.push(`@param${index + 1}`, strings[index + 1])
+      if (Array.isArray(value)) {//if value is an array, prepare each items and add a coma between each item
+        for (let arrayIndex = 0; arrayIndex < value.length - 1; arrayIndex++) {
+          this.input(`param${index + 1}_${arrayIndex}`, value[arrayIndex])
+          command.push(`@param${index + 1}_${arrayIndex}`, ',')
+        }
+        this.input(`param${index + 1}_${value.length - 1}`, value[value.length - 1])
+        command.push(`@param${index + 1}_${value.length - 1}`, strings[index + 1])
+      } else {
+        this.input(`param${index + 1}`, value)
+        command.push(`@param${index + 1}`, strings[index + 1])
+      }
     }
 
     if (method) {

--- a/lib/base.js
+++ b/lib/base.js
@@ -999,13 +999,17 @@ class Request extends EventEmitter {
 
     for (let index = 0; index < values.length; index++) {
       let value = values[index]
-      if (Array.isArray(value)) {//if value is an array, prepare each items and add a coma between each item
-        for (let arrayIndex = 0; arrayIndex < value.length - 1; arrayIndex++) {
-          this.input(`param${index + 1}_${arrayIndex}`, value[arrayIndex])
-          command.push(`@param${index + 1}_${arrayIndex}`, ',')
+      // if value is an array, prepare each items as it's own comma separated parameter
+      if (Array.isArray(value)) {
+        for (let parameterIndex = 0; parameterIndex < value.length; parameterIndex++) {
+          this.input(`param${index + 1}_${parameterIndex}`, value[parameterIndex])
+          command.push(`@param${index + 1}_${parameterIndex}`)
+          if (parameterIndex < value.length - 1) {
+            command.push(', ')
+          } else {
+            command.push(strings[index + 1])
+          }
         }
-        this.input(`param${index + 1}_${value.length - 1}`, value[value.length - 1])
-        command.push(`@param${index + 1}_${value.length - 1}`, strings[index + 1])
       } else {
         this.input(`param${index + 1}`, value)
         command.push(`@param${index + 1}`, strings[index + 1])

--- a/test/common/templatestring.js
+++ b/test/common/templatestring.js
@@ -20,6 +20,15 @@ module.exports = (sql, driver) => {
 
         done()
       }).catch(done)
+    },
+
+    'array params' (done) {
+      let values = [1, 2, 3]
+      sql.query`select 1 as col where 1 in (${values});`.then(result => {
+        assert.strictEqual(result.recordset[0].col, 1)
+
+        done()
+      })
     }
   }
 }

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -211,4 +211,23 @@ describe('Unit', () => {
       command: 'select * from myTable where id = @param1'
     })
   })
+
+  it('tagged template arrays', () => {
+    function query () {
+      const values = Array.prototype.slice.call(arguments)
+      const strings = values.shift()
+      const input = []
+      return {
+        input: input,
+        command: sql.Request.prototype._template.call({
+          input () { input.push(Array.prototype.slice.call(arguments)) }
+        }, strings, values)
+      }
+    }
+
+    assert.deepEqual(query`select * from myTable where id in (${[1, 2, 3]})`, {
+      input: [['param1_0', 1], ['param1_1', 2], ['param1_2', 3]],
+      command: 'select * from myTable where id in (@param1_0, @param1_1, @param1_2)'
+    })
+  })
 })

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -170,6 +170,7 @@ describe('tedious', () => {
 
     it('query', done => TEMPLATE_STRING['query'](done))
     it('batch', done => TEMPLATE_STRING['batch'](done))
+    it('array params', done => TEMPLATE_STRING['array params'](done))
 
     after(done => sql.close(done))
   })


### PR DESCRIPTION
When passing an array to a string litteral template, each item of this array is prepared.

This let you do as follow :

```
connector.query`SELECT * FROM table WHERE name in (${array})`
```

Instead of :
```
connector.query`SELECT * FROM table WHERE name in (${array[0]},${array[1]},${array[2]}...)`
connector.query`SELECT * FROM table WHERE name in (${array.map((v, i) => `@array${i}`).join(', ')})`
```