### PR TITLE
Connection Pool Template Strings/Tagged functions

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1271,9 +1271,10 @@ class Request extends EventEmitter {
         })
       })
       return this
-    } else if (typeof callback === 'string') {
-      const values = Array.prototype.slice.call(arguments)
-      const strings = values.shift()
+    }
+    if (typeof command === 'object') {
+      const values = Array.prototype.slice.call(arguments);
+      const strings = values.shift();
       command = this._processTemplate(strings, values);
     }
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -1226,8 +1226,8 @@ class Request extends EventEmitter {
    * @param {Array} values
    * @return {String}
    */
-  
-  _processTemplate(strings, values){
+
+  _processTemplate (strings, values) {
     let command = [strings[0]]
 
     for (let index = 0; index < values.length; index++) {
@@ -1235,7 +1235,7 @@ class Request extends EventEmitter {
       this.input(`param${index + 1}`, value)
       command.push(`@param${index + 1}`, strings[index + 1])
     }
-    return command.join('');
+    return command.join('')
   }
 
   /**
@@ -1273,9 +1273,9 @@ class Request extends EventEmitter {
       return this
     }
     if (typeof command === 'object') {
-      const values = Array.prototype.slice.call(arguments);
-      const strings = values.shift();
-      command = this._processTemplate(strings, values);
+      const values = Array.prototype.slice.call(arguments)
+      const strings = values.shift()
+      command = this._processTemplate(strings, values)
     }
 
     return new PromiseLibrary((resolve, reject) => {

--- a/lib/base.js
+++ b/lib/base.js
@@ -981,15 +981,7 @@ class Request extends EventEmitter {
    */
 
   _template (method, strings, values) {
-    let command = [strings[0]]
-
-    for (let index = 0; index < values.length; index++) {
-      let value = values[index]
-      this.input(`param${index + 1}`, value)
-      command.push(`@param${index + 1}`, strings[index + 1])
-    }
-
-    return this[method](command.join(''))
+    return this[method](this._processTemplate(strings, values))
   }
 
   /**
@@ -1227,6 +1219,26 @@ class Request extends EventEmitter {
   }
 
   /**
+   * Generate T-SQL command from template literal
+   *
+   * @private
+   * @param {Array} strings
+   * @param {Array} values
+   * @return {String}
+   */
+  
+  _processTemplate(strings, values){
+    let command = [strings[0]]
+
+    for (let index = 0; index < values.length; index++) {
+      let value = values[index]
+      this.input(`param${index + 1}`, value)
+      command.push(`@param${index + 1}`, strings[index + 1])
+    }
+    return command.join('');
+  }
+
+  /**
    * Execute the SQL command.
    *
    * @param {String} command T-SQL command to be executed.
@@ -1259,6 +1271,10 @@ class Request extends EventEmitter {
         })
       })
       return this
+    } else if (typeof callback === 'string') {
+      const values = Array.prototype.slice.call(arguments)
+      const strings = values.shift()
+      command = this._processTemplate(strings, values);
     }
 
     return new PromiseLibrary((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "azure",
     "node-mssql"
   ],
-  "version": "4.1.0",
+  "version": "4.1.1",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We are using MS SQL connection pools and found that template literals did not work; I extracted the code for cleaning and processing the template literals from `_template` into `_processTemplate`.

This is so it can be used to generate T-SQL commands for `Request.query` where a template literal would give an object as the first argument.