### PR TITLE
semver-MAJOR add beforeConnect handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,13 @@ Default driver, actively maintained and production ready. Platform independent, 
 
 **Extra options:**
 
+- **beforeConnect(conn)** - Function, which is invoked before opening the connection. The parameter `conn` is the configured tedious `Connection`. It can be used for attaching event handlers like in this example:
+```js
+require('mssql').connect(...config, beforeConnect: conn => {
+  conn.once('connect', err => { err ? console.error(err) : console.log('mssql connected')})
+  conn.once('end', err => { err ? console.error(err) : console.log('mssql disconnected')})
+}})
+```
 - **options.instanceName** - The instance name to connect to. The SQL Server Browser service must be running on the database server, and UDP port 1434 on the database server must be reachable.
 - **options.useUTC** - A boolean determining whether or not use UTC time for values without time zone offset (default: `true`).
 - **options.encrypt** - A boolean determining whether or not the connection will be encrypted (default: `false`).
@@ -420,6 +427,7 @@ More information about Tedious specific options: http://tediousjs.github.io/tedi
 
 **Extra options:**
 
+- **beforeConnect(conn)** - Function, which is invoked before opening the connection. The parameter `conn` is the connection configuration, that can be modified to pass extra parameters to the driver's `open()` method.
 - **connectionString** - Connection string (default: see below).
 - **options.instanceName** - The instance name to connect to. The SQL Server Browser service must be running on the database server, and UDP port 1444 on the database server must be reachable.
 - **options.trustedConnection** - Use Windows Authentication (default: `false`).

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -183,6 +183,10 @@ class ConnectionPool extends base.ConnectionPool {
       debug('pool(%d): connection #%d created', IDS.get(this), connedtionId)
       debug('connection(%d): establishing', connedtionId)
 
+      if (typeof this.config.beforeConnect === 'function') {
+        this.config.beforeConnect(cfg)
+      }
+
       msnodesql.open(cfg, (err, tds) => {
         if (err) {
           err = new base.ConnectionError(err)

--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -258,6 +258,9 @@ class ConnectionPool extends base.ConnectionPool {
       if (this.config.debug) {
         tedious.on('debug', this.emit.bind(this, 'debug', tedious))
       }
+      if (typeof this.config.beforeConnect === 'function') {
+        this.config.beforeConnect(tedious)
+      }
     })
   }
 


### PR DESCRIPTION
Allow mutating the tedious connection by passing it to a beforeConnect handler, passed in the configuration object. 
This for example allows to tap into the tedious.debug methods and collect metrics or monitor connect, end or other events on the connection.