### PR TITLE
Detect closed tedious client during pool create

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ sudo: false
 node_js:
   - "4"
   - "6"
+  - "8"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+  version: '3'
+
+services:
+  toxiproxy:
+    image: shopify/toxiproxy
+    ports:
+      - "8474:8474"
+      - "21433:21433"
+    links:
+      - "mssql"
+
+  mssql:
+    image: microsoft/mssql-server-linux:2017-latest
+    ports:
+      - "31433:1433"
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=S0meVeryHardPassword
+
+  initmssqtestdb:
+    image: microsoft/mssql-server-linux:2017-latest
+    links:
+      - mssql
+    entrypoint: 
+      - /opt/mssql-tools/bin/sqlcmd 
+      - -S 
+      - mssql 
+      - -U 
+      - sa 
+      - -P 
+      - S0meVeryHardPassword 
+      - -d 
+      - master
+      - -Q 
+      - "CREATE DATABASE mssql_test_db"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-  version: '3'
+version: '3'
 
 services:
   toxiproxy:

--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -211,6 +211,14 @@ class ConnectionPool extends base.ConnectionPool {
 
       const tedious = new tds.Connection(cfg)
 
+      tedious.on('debug', msg => {
+        if (tedious.closed) {
+          reject(new base.ConnectionError(
+            new Error('Tedious closed connection without emitting "connect","error" nor "end" events.')
+          ))
+        }
+      })
+
       tedious.once('connect', err => {
         if (err) {
           err = new base.ConnectionError(err)

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "test": "standard && node_modules/.bin/mocha test/common/unit.js",
     "test-tedious": "node_modules/.bin/mocha test/tedious",
     "test-msnodesqlv8": "node_modules/.bin/mocha test/msnodesqlv8",
-    "test-cli": "node_modules/.bin/mocha test/common/cli.js"
+    "test-cli": "node_modules/.bin/mocha test/common/cli.js",
+    "mssql-server:up": "docker-compose up --no-start &&  docker-compose start",
+    "mssql-server:down": "docker-compose down"
   },
   "bin": {
     "mssql": "./bin/mssql"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   },
   "devDependencies": {
     "mocha": "^2.1.0",
-    "standard": "^9.0.2"
+    "request-promise-native": "^1.0.5",
+    "standard": "^9.0.2",
+    "toxiproxy-node-client": "^2.0.6"
   },
   "engines": {
     "node": ">=4"
@@ -46,7 +48,9 @@
     "test-msnodesqlv8": "node_modules/.bin/mocha test/msnodesqlv8",
     "test-cli": "node_modules/.bin/mocha test/common/cli.js",
     "mssql-server:up": "docker-compose up --no-start &&  docker-compose start",
-    "mssql-server:down": "docker-compose down"
+    "mssql-server:down": "docker-compose down",
+    "stress:tedious:debug": "DEBUG=* npm run stress:tedious",
+    "stress:tedious": "TEST_DRIVER=tedious node test/stress/pool-create-hanging.js"
   },
   "bin": {
     "mssql": "./bin/mssql"

--- a/test/.mssql-docker.json
+++ b/test/.mssql-docker.json
@@ -1,0 +1,7 @@
+{
+  "port": 31433,
+  "user": "sa",
+  "password": "S0meVeryHardPassword",
+  "server": "localhost",
+  "database": "mssql_test_db"
+}

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const stream = require('stream')
 
-function clone(val) { return Object.assign({}, val); }
+function clone (val) { return Object.assign({}, val) }
 
 process.on('unhandledRejection', (reason, p) => {
   console.log('Unhandled Rejection at: Promise', p, 'reason:', reason)

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -3,6 +3,8 @@
 const assert = require('assert')
 const stream = require('stream')
 
+function clone(val) { return Object.assign({}, val); }
+
 process.on('unhandledRejection', (reason, p) => {
   console.log('Unhandled Rejection at: Promise', p, 'reason:', reason)
   // application specific logging, throwing an error, or other logic here
@@ -648,7 +650,7 @@ module.exports = (sql, driver) => {
     },
 
     'request timeout' (done, driver, message) {
-      const config = JSON.parse(require('fs').readFileSync(`${__dirname}/../.mssql.json`))
+      const config = clone(require('../mssql-config'))
       config.driver = driver
       config.requestTimeout = 1000  // note: msnodesqlv8 doesn't support timeouts less than 1 second
 
@@ -760,7 +762,7 @@ module.exports = (sql, driver) => {
     },
 
     'login failed' (done, message) {
-      const config = JSON.parse(require('fs').readFileSync(`${__dirname}/../.mssql.json`))
+      const config = clone(require('../mssql-config'))
       config.user = '__notexistinguser__'
 
       // eslint-disable-next-line no-new
@@ -950,7 +952,7 @@ module.exports = (sql, driver) => {
       }
 
       __range__(1, peak, true).map((i) => {
-        const c = new sql.ConnectionPool(JSON.parse(require('fs').readFileSync(`${__dirname}/../.mssql.json`)))
+        const c = new sql.ConnectionPool(require('../mssql-config'))
         c.connect(connected)
         conns.push(c)
       })
@@ -959,7 +961,7 @@ module.exports = (sql, driver) => {
     'concurrent requests' (done, driver) {
       console.log('')
 
-      let config = JSON.parse(require('fs').readFileSync(`${__dirname}/../.mssql.json`))
+      let config = clone(require('../mssql-config'))
       config.driver = driver
       config.pool = {min: 0, max: 50}
 
@@ -1004,7 +1006,7 @@ module.exports = (sql, driver) => {
     },
 
     'streaming off' (done, driver) {
-      let config = JSON.parse(require('fs').readFileSync(`${__dirname}/../.mssql.json`))
+      let config = clone(require('../mssql-config'))
       config.driver = driver
       config.requestTimeout = 60000
 
@@ -1023,7 +1025,7 @@ module.exports = (sql, driver) => {
     },
 
     'streaming on' (done, driver) {
-      let config = JSON.parse(require('fs').readFileSync(`${__dirname}/../.mssql.json`))
+      let config = clone(require('../mssql-config'))
       config.driver = driver
       config.requestTimeout = 60000
 

--- a/test/mssql-config.js
+++ b/test/mssql-config.js
@@ -1,0 +1,9 @@
+let config = null;
+
+try {
+  config = require(`./.mssql.json`)
+} catch (e) {
+  config = require(`./.mssql-docker.json`)        
+}
+
+module.exports = config;

--- a/test/mssql-config.js
+++ b/test/mssql-config.js
@@ -1,9 +1,9 @@
-let config = null;
+let config = null
 
 try {
   config = require(`./.mssql.json`)
 } catch (e) {
-  config = require(`./.mssql-docker.json`)        
+  config = require(`./.mssql-docker.json`)
 }
 
-module.exports = config;
+module.exports = config

--- a/test/stress/pool-create-hanging.js
+++ b/test/stress/pool-create-hanging.js
@@ -1,0 +1,193 @@
+/**
+ * Test case for figuring out robust way to recognize if connection is dead
+ * for mysql based drivers.
+ */
+const toxiproxy = require('toxiproxy-node-client');
+const toxicli = new toxiproxy.Toxiproxy('http://localhost:8474');
+const rp = require('request-promise-native');
+const _ = require('lodash');
+
+const mssql = require('../../' + process.env.TEST_DRIVER);
+const debug = require('debug')('mssql-stress');
+
+function delay(ms) {
+  return new Promise((resolve, reject) => {
+    setTimeout(resolve, ms);
+  })
+}
+
+function cloneDeep(val) {
+  return JSON.parse(JSON.stringify(val)); 
+}
+
+// initial dummy object, which will be overridden by connection process
+let mssqlCon = { connected: false };
+let connectionNumber = 0;
+
+async function mssqlQuery(sql) {
+  // recreate connection is not connected / connecting stus
+  if (!mssqlCon.connected && !mssqlCon.connecting) {
+    debug('========== Reconnecting mssql');
+
+    // this test needs toxiproxy to run so docker mssql is also required
+    mssqlCon = new mssql.ConnectionPool({
+      port: 21433,
+      user: "sa",
+      password: "S0meVeryHardPassword",
+      server: "localhost",
+      requestTimeout: 5000,
+      connectionTimeout:7000,
+      debug: true,
+      pool: {
+        debug: true,
+        min: 1,
+        max: 1,
+        acquireTimeoutMillis: 10000,
+        testOnBorrow: true
+      }
+    });
+
+    mssqlCon.connectionNumber = connectionNumber += 1;
+
+    // NOTE: this never seems to fire
+    mssqlCon.on('error', err => {
+      debug('There was fatal connection error %O', err);
+    });
+
+    debug('Waiting for connection');
+    await mssqlCon.connect();
+  }
+
+  debug('>>>>>>>>>>>>>>>> Running query >>>>>>>>>>>>>>>');
+  debug('%o', {
+    peding: mssqlCon.pool.pending,
+    size: mssqlCon.pool.size,
+    available: mssqlCon.pool.available,
+    spareResourceCapacity: mssqlCon.pool.spareResourceCapacity,
+    borrowed: mssqlCon.pool.borrowed,
+  });
+  const res = await mssqlCon.request().query(sql);
+  debug('query response %o', res.recordset);
+  debug('<<<<<<<<<<<<<<<<< query  done <<<<<<<<<<<<<<<<');
+  return res;
+}
+
+// setup counters to check queries / results / errors made since last report
+const counters = {};
+function setQueryCounters(name) {
+  const counts = counters[name] = {queries: 0, results: 0, errors: 0};
+}
+setQueryCounters('mssql');
+
+// start printing out counters
+let lastCounters = cloneDeep(counters);
+let hangRounds = 0;
+let statsInterval = setInterval(() => {
+  const reqsPerSec = {};
+  for (let key of Object.keys(counters)) {
+    reqsPerSec[key] = {
+      queries: (counters[key].queries - lastCounters[key].queries),
+      results: (counters[key].results - lastCounters[key].results),
+      errors: (counters[key].errors - lastCounters[key].errors),
+    }
+  }
+
+  console.log('------------------------ REQUESTS SINCE LAST PRINT ------------------------');
+  if (mssqlCon.pool) {
+    console.dir({
+      peding: mssqlCon.pool.pending,
+      size: mssqlCon.pool.size,
+      available: mssqlCon.pool.available,
+      borrowed: mssqlCon.pool.borrowed,
+    });
+  }
+  console.dir(reqsPerSec, { colors: true });
+  console.log('------------------------------------ EOS ---------------------------------');
+  lastCounters = cloneDeep(counters);
+
+  if (reqsPerSec.mssql.queries === 0) {
+    hangRounds++;
+  } else {
+    hangRounds = 0;
+  }
+
+  if (hangRounds === 3) {
+    console.log('Driver did hang exit with error');
+    process.exit(1);
+  }
+}, 500);
+
+/**
+ * Kill old proxy instance and its connections if found and create new
+ * proxy waiting for connections.
+ */
+async function recreateProxy(serviceName, listenPort, proxyToPort) {
+  try {
+    await rp.delete({
+      url: `${toxicli.host}/proxies/${serviceName}`
+    });
+  } catch(err) {}
+
+  const proxy = await toxicli.createProxy({
+    name: serviceName,
+    listen: `0.0.0.0:${listenPort}`,
+    upstream: `${serviceName}:${proxyToPort}`
+  });
+
+  // add some network latency simulation
+  await proxy.addToxic(new toxiproxy.Toxic(proxy, {
+    type: 'latency',
+    attributes: {latency: 1, jitter: 1}
+  }));
+
+  // cause connections to be closed every some transferred bytes
+  await proxy.addToxic(new toxiproxy.Toxic(proxy, {
+    type: 'limit_data',
+    attributes: {bytes: 5000}
+  }));
+}
+
+async function main() {
+  await recreateProxy('mssql', 21433, 1433);
+  // break connections every second
+  let connectionKillerInterval = setInterval(() => recreateProxy('mssql', 21433, 1433), 1000);
+
+  // loop queries and log any errors thrown
+  function loopQueries(prefix, query) {
+    const counts = counters[prefix];
+    let keepOnSwimming = true;
+
+    async function asyncQueryLoopRun() {
+      while(keepOnSwimming) {
+        try {
+          counts.queries += 1;
+          await query();
+          counts.results += 1;
+        } catch (err) {
+          counts.errors += 1;
+          debug('%s %O', prefix, err);
+        }
+      }  
+    }
+
+    let loopPromise = asyncQueryLoopRun();
+
+    return () => {
+      keepOnSwimming = false;
+      return loopPromise;
+    };
+  }
+
+  killQueryLoop = loopQueries('mssql', () => mssqlQuery('select 1 as number'));
+
+  // should fail in few seconds
+  await delay(10000);
+
+  console.log('killing loop');
+  clearInterval(connectionKillerInterval);
+  clearInterval(statsInterval);
+  await killQueryLoop();
+  mssqlCon.close();
+}
+
+main().then(() => console.log('TEST DONE EXIT SUCCESS')).catch(err => console.log('TEST FAIL WITH ERROR %O', err));

--- a/test/stress/pool-create-hanging.js
+++ b/test/stress/pool-create-hanging.js
@@ -2,41 +2,40 @@
  * Test case for figuring out robust way to recognize if connection is dead
  * for mysql based drivers.
  */
-const toxiproxy = require('toxiproxy-node-client');
-const toxicli = new toxiproxy.Toxiproxy('http://localhost:8474');
-const rp = require('request-promise-native');
-const _ = require('lodash');
+const toxiproxy = require('toxiproxy-node-client')
+const toxicli = new toxiproxy.Toxiproxy('http://localhost:8474')
+const rp = require('request-promise-native')
 
-const mssql = require('../../' + process.env.TEST_DRIVER);
-const debug = require('debug')('mssql-stress');
+const mssql = require('../../' + process.env.TEST_DRIVER)
+const debug = require('debug')('mssql-stress')
 
-function delay(ms) {
+function delay (ms) {
   return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms);
+    setTimeout(resolve, ms)
   })
 }
 
-function cloneDeep(val) {
-  return JSON.parse(JSON.stringify(val)); 
+function cloneDeep (val) {
+  return JSON.parse(JSON.stringify(val))
 }
 
 // initial dummy object, which will be overridden by connection process
-let mssqlCon = { connected: false };
-let connectionNumber = 0;
+let mssqlCon = { connected: false }
+let connectionNumber = 0
 
-async function mssqlQuery(sql) {
+async function mssqlQuery (sql) {
   // recreate connection is not connected / connecting stus
   if (!mssqlCon.connected && !mssqlCon.connecting) {
-    debug('========== Reconnecting mssql');
+    debug('========== Reconnecting mssql')
 
     // this test needs toxiproxy to run so docker mssql is also required
     mssqlCon = new mssql.ConnectionPool({
       port: 21433,
-      user: "sa",
-      password: "S0meVeryHardPassword",
-      server: "localhost",
+      user: 'sa',
+      password: 'S0meVeryHardPassword',
+      server: 'localhost',
       requestTimeout: 5000,
-      connectionTimeout:7000,
+      connectionTimeout: 7000,
       debug: true,
       pool: {
         debug: true,
@@ -45,149 +44,150 @@ async function mssqlQuery(sql) {
         acquireTimeoutMillis: 10000,
         testOnBorrow: true
       }
-    });
+    })
 
-    mssqlCon.connectionNumber = connectionNumber += 1;
+    mssqlCon.connectionNumber = connectionNumber += 1
 
     // NOTE: this never seems to fire
     mssqlCon.on('error', err => {
-      debug('There was fatal connection error %O', err);
-    });
+      debug('There was fatal connection error %O', err)
+    })
 
-    debug('Waiting for connection');
-    await mssqlCon.connect();
+    debug('Waiting for connection')
+    await mssqlCon.connect()
   }
 
-  debug('>>>>>>>>>>>>>>>> Running query >>>>>>>>>>>>>>>');
+  debug('>>>>>>>>>>>>>>>> Running query >>>>>>>>>>>>>>>')
   debug('%o', {
     peding: mssqlCon.pool.pending,
     size: mssqlCon.pool.size,
     available: mssqlCon.pool.available,
     spareResourceCapacity: mssqlCon.pool.spareResourceCapacity,
-    borrowed: mssqlCon.pool.borrowed,
-  });
-  const res = await mssqlCon.request().query(sql);
-  debug('query response %o', res.recordset);
-  debug('<<<<<<<<<<<<<<<<< query  done <<<<<<<<<<<<<<<<');
-  return res;
+    borrowed: mssqlCon.pool.borrowed
+  })
+  const res = await mssqlCon.request().query(sql)
+  debug('query response %o', res.recordset)
+  debug('<<<<<<<<<<<<<<<<< query  done <<<<<<<<<<<<<<<<')
+  return res
 }
 
 // setup counters to check queries / results / errors made since last report
-const counters = {};
-function setQueryCounters(name) {
-  const counts = counters[name] = {queries: 0, results: 0, errors: 0};
+const counters = {}
+function setQueryCounters (name) {
+  counters[name] = {queries: 0, results: 0, errors: 0}
 }
-setQueryCounters('mssql');
+setQueryCounters('mssql')
 
 // start printing out counters
-let lastCounters = cloneDeep(counters);
-let hangRounds = 0;
+let lastCounters = cloneDeep(counters)
+let hangRounds = 0
 let statsInterval = setInterval(() => {
-  const reqsPerSec = {};
+  const reqsPerSec = {}
   for (let key of Object.keys(counters)) {
     reqsPerSec[key] = {
       queries: (counters[key].queries - lastCounters[key].queries),
       results: (counters[key].results - lastCounters[key].results),
-      errors: (counters[key].errors - lastCounters[key].errors),
+      errors: (counters[key].errors - lastCounters[key].errors)
     }
   }
 
-  console.log('------------------------ REQUESTS SINCE LAST PRINT ------------------------');
+  console.log('------------------------ REQUESTS SINCE LAST PRINT ------------------------')
   if (mssqlCon.pool) {
     console.dir({
       peding: mssqlCon.pool.pending,
       size: mssqlCon.pool.size,
       available: mssqlCon.pool.available,
-      borrowed: mssqlCon.pool.borrowed,
-    });
+      borrowed: mssqlCon.pool.borrowed
+    })
   }
-  console.dir(reqsPerSec, { colors: true });
-  console.log('------------------------------------ EOS ---------------------------------');
-  lastCounters = cloneDeep(counters);
+  console.dir(reqsPerSec, { colors: true })
+  console.log('------------------------------------ EOS ---------------------------------')
+  lastCounters = cloneDeep(counters)
 
   if (reqsPerSec.mssql.queries === 0) {
-    hangRounds++;
+    hangRounds++
   } else {
-    hangRounds = 0;
+    hangRounds = 0
   }
 
   if (hangRounds === 3) {
-    console.log('Driver did hang exit with error');
-    process.exit(1);
+    console.log('Driver did hang exit with error')
+    process.exit(1)
   }
-}, 500);
+}, 500)
 
 /**
  * Kill old proxy instance and its connections if found and create new
  * proxy waiting for connections.
  */
-async function recreateProxy(serviceName, listenPort, proxyToPort) {
+async function recreateProxy (serviceName, listenPort, proxyToPort) {
   try {
     await rp.delete({
       url: `${toxicli.host}/proxies/${serviceName}`
-    });
-  } catch(err) {}
+    })
+  } catch (err) {}
 
   const proxy = await toxicli.createProxy({
     name: serviceName,
     listen: `0.0.0.0:${listenPort}`,
     upstream: `${serviceName}:${proxyToPort}`
-  });
+  })
 
   // add some network latency simulation
   await proxy.addToxic(new toxiproxy.Toxic(proxy, {
     type: 'latency',
     attributes: {latency: 1, jitter: 1}
-  }));
+  }))
 
   // cause connections to be closed every some transferred bytes
   await proxy.addToxic(new toxiproxy.Toxic(proxy, {
     type: 'limit_data',
     attributes: {bytes: 5000}
-  }));
+  }))
 }
 
-async function main() {
-  await recreateProxy('mssql', 21433, 1433);
+async function main () {
+  await recreateProxy('mssql', 21433, 1433)
   // break connections every second
-  let connectionKillerInterval = setInterval(() => recreateProxy('mssql', 21433, 1433), 1000);
+  let connectionKillerInterval = setInterval(() => recreateProxy('mssql', 21433, 1433), 1000)
 
   // loop queries and log any errors thrown
-  function loopQueries(prefix, query) {
-    const counts = counters[prefix];
-    let keepOnSwimming = true;
+  function loopQueries (prefix, query) {
+    const counts = counters[prefix]
+    let keepOnSwimming = true
 
-    async function asyncQueryLoopRun() {
-      while(keepOnSwimming) {
+    async function asyncQueryLoopRun () {
+      while (true) {
+        if (!keepOnSwimming) break
         try {
-          counts.queries += 1;
-          await query();
-          counts.results += 1;
+          counts.queries += 1
+          await query()
+          counts.results += 1
         } catch (err) {
-          counts.errors += 1;
-          debug('%s %O', prefix, err);
+          counts.errors += 1
+          debug('%s %O', prefix, err)
         }
-      }  
+      }
     }
 
-    let loopPromise = asyncQueryLoopRun();
+    let loopPromise = asyncQueryLoopRun()
 
     return () => {
-      keepOnSwimming = false;
-      return loopPromise;
-    };
+      keepOnSwimming = false
+      return loopPromise
+    }
   }
 
-  killQueryLoop = loopQueries('mssql', () => mssqlQuery('select 1 as number'));
+  const killQueryLoop = loopQueries('mssql', () => mssqlQuery('select 1 as number'))
 
   // should fail in few seconds
-  await delay(10000);
+  await delay(10000)
 
-  console.log('killing loop');
-  clearInterval(connectionKillerInterval);
-  clearInterval(statsInterval);
-  await killQueryLoop();
-  mssqlCon.close();
+  console.log('killing loop')
+  clearInterval(connectionKillerInterval)
+  clearInterval(statsInterval)
+  await killQueryLoop()
+  mssqlCon.close()
 }
 
-main().then(() => console.log('TEST DONE EXIT SUCCESS')).catch(err => console.log('TEST FAIL WITH ERROR %O', err));
+main().then(() => console.log('TEST DONE EXIT SUCCESS')).catch(err => console.log('TEST FAIL WITH ERROR %O', err))

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -13,9 +13,7 @@ if (parseInt(process.version.match(/^v(\d+)\./)[1]) > 0) {
   require('../common/templatestring.js')
 }
 
-function clone(val) {
-  return Object.assign({}, val);
-}
+function clone(val) { return Object.assign({}, val); }
 
 const config = function () {
   let cfg = clone(require('../mssql-config'));

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -13,8 +13,12 @@ if (parseInt(process.version.match(/^v(\d+)\./)[1]) > 0) {
   require('../common/templatestring.js')
 }
 
+function clone(val) {
+  return Object.assign({}, val);
+}
+
 const config = function () {
-  let cfg = JSON.parse(require('fs').readFileSync(`${__dirname}/../.mssql.json`))
+  let cfg = clone(require('../mssql-config'));
   cfg.driver = 'tedious'
   return cfg
 }

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -13,10 +13,10 @@ if (parseInt(process.version.match(/^v(\d+)\./)[1]) > 0) {
   require('../common/templatestring.js')
 }
 
-function clone(val) { return Object.assign({}, val); }
+function clone (val) { return Object.assign({}, val) }
 
 const config = function () {
-  let cfg = clone(require('../mssql-config'));
+  let cfg = clone(require('../mssql-config'))
   cfg.driver = 'tedious'
   return cfg
 }


### PR DESCRIPTION
During stress testing of knex I found out that mssql driver seemed to be really unstable, when connections are closed at unexpected locations. Actually I was able to trace the problem to the tedious driver, but it makes more sense to have stress test made in mssql, because that way also other drivers can be tested to work fine with the same code.

This PR includes stress test for mssql driver, docker setup for starting up mssql server on any platform with additional support for emulating network problems with TCP proxy.

The actual problem was that in some edge cases when connection is closed unexpectedly tedious driver does not emit `connect`, `error` nor `end` event thus `poolCreate` hangs until acquireConnection timeout.

What I did find out that tedious did emit `debug` events and did set `tedious.closed` status correctly, even when other events were not emitted. So for work around I detect closed tedious connection in `debug` event and reject pool creation as soon as it is seen in debug events that connection is closed.

Separate problem (that is not fixed by this PR) is why acquire timeout didn't resolve faulty poolCreate functionality and all the following queries did hang until timeout too.