### PR TITLE
replaces generic-pool with tarnjs

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -2,7 +2,7 @@
 
 const EventEmitter = require('events').EventEmitter
 const debug = require('debug')('mssql')
-const gp = require('generic-pool')
+const gp = require('tarn')
 
 const TYPES = require('./datatypes').TYPES
 const declare = require('./datatypes').declare
@@ -169,11 +169,11 @@ class ConnectionPool extends EventEmitter {
     debug('conn: acquire')
 
     if (typeof callback === 'function') {
-      this._acquire().then(connection => callback(null, connection, this.config)).catch(callback)
+      this._acquire().promise.then(connection => callback(null, connection, this.config)).catch(callback)
       return this
     }
 
-    return this._acquire()
+    return this._acquire().promise
   }
 
   _acquire () {
@@ -244,21 +244,17 @@ class ConnectionPool extends EventEmitter {
       }
 
       // prepare pool
-      this.pool = gp.createPool({
-        create: this._poolCreate.bind(this),
-        validate: this._poolValidate.bind(this),
-        destroy: this._poolDestroy.bind(this)
-      }, Object.assign({
-        max: 10,
-        min: 0,
-        acquireTimeoutMillis: this.config.connectionTimeout || this.config.timeout || 15000,
-        evictionRunIntervalMillis: 1000,
-        idleTimeoutMillis: 30000,
-        testOnBorrow: true
-      }, this.config.pool))
-
-      this.pool.on('factoryCreateError', this.emit.bind(this, 'error'))
-      this.pool.on('factoryDestroyError', this.emit.bind(this, 'error'))
+      this.pool = new tarn.Pool(
+        Object.assign({
+          create: this._poolCreate.bind(this),
+          validate: this._poolValidate.bind(this),
+          destroy: this._poolDestroy.bind(this),
+          max: 10,
+          min: 0,
+          acquireTimeoutMillis: this.config.connectionTimeout || this.config.timeout || 15000,
+          idleTimeoutMillis: 30000,
+          propagateCreateError: true
+        }, this.config.pool))
 
       this._connecting = false
       this._connected = true
@@ -301,13 +297,11 @@ class ConnectionPool extends EventEmitter {
 
     if (!this.pool) return setImmediate(callback, null)
 
-    const pool = this.pool
-    this.pool.drain().then(() => {
-      pool.clear()
-      callback(null)
-    })
-
+    this.pool.destroy()
     this.pool = null
+    if (typeof callback === 'function') {
+      callback()
+    }
   }
 
   /**

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -187,9 +187,7 @@ class ConnectionPool extends base.ConnectionPool {
   }
 
   _poolValidate (tds) {
-    return new base.Promise((resolve, reject) => {
-      resolve(!tds.hasError)
-    })
+      return !tds.hasError
   }
 
   _poolDestroy (tds) {

--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -236,9 +236,7 @@ class ConnectionPool extends base.ConnectionPool {
   }
 
   _poolValidate (tedious) {
-    return new base.Promise((resolve, reject) => {
-      resolve(!tedious.closed && !tedious.hasError)
-    })
+    return !tedious.closed && !tedious.hasError
   }
 
   _poolDestroy (tedious) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^2.6.3",
-    "generic-pool": "^3.1.7",
+    "tarn": "^1.1.4",
     "tedious": "^2.0.0"
   },
   "devDependencies": {

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -801,10 +801,9 @@ module.exports = (sql, driver) => {
       const complete = () =>
         setTimeout(() => {
           // this must be delayed because destroying connection take some time
-          assert.equal(connection.pool.size, 3)
-          assert.equal(connection.pool.available, 3)
-          assert.equal(connection.pool.pending, 0)
-          assert.equal(connection.pool.borrowed, 0)
+          assert.equal(connection.pool.free.length + connection.pool.used.length + connection.pool.pendingCreates.length, 3)
+          assert.equal(connection.pool.free.length, 3)
+          assert.equal(connection.pool.pendingCreates.length, 0)
           done()
         }, 500)
 
@@ -867,10 +866,9 @@ module.exports = (sql, driver) => {
       })
 
       setImmediate(() => {
-        assert.equal(connection.pool.size, 1)
-        assert.equal(connection.pool.available, 0)
-        assert.equal(connection.pool.pending, 3)
-        assert.equal(connection.pool.borrowed, 0)
+        assert.equal(connection.pool.free.length + connection.pool.used.length + connection.pool.pendingCreates.length, 1)
+        assert.equal(connection.pool.free.length, 0)
+        assert.equal(connection.pool.pendingAcquires.length, 3)
       })
     },
 
@@ -885,10 +883,9 @@ module.exports = (sql, driver) => {
         r3.query('select 1', function (err, result) {
           if (err) return done(err)
 
-          assert.equal(connection2.pool.size, 1)
-          assert.equal(connection2.pool.available, 1)
-          assert.equal(connection2.pool.pending, 0)
-          assert.equal(connection2.pool.borrowed, 0)
+          assert.equal(connection2.pool.free.length + connection2.pool.used.length + connection2.pool.pendingCreates.length, 1)
+          assert.equal(connection2.pool.free.length, 1)
+          assert.equal(connection2.pool.pendingAcquires.length, 0)
 
           done()
         })


### PR DESCRIPTION
my team has noticed issues with the generic pool leaving connection creation and nevery timing them out.  Tarnjs adds the ability to timeout connection creations which make the mssql package more robust.