### PR TITLE
Add support for informational message capturing with msnodesqlv8

### DIFF
--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -171,7 +171,7 @@ class ConnectionPool extends base.ConnectionPool {
           default:
             return this.config[key] != null ? this.config[key] : ''
         }
-      });
+      })
 
       msnodesql.open(cfg, (err, tds) => {
         if (err) {

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -171,7 +171,7 @@ class ConnectionPool extends base.ConnectionPool {
           default:
             return this.config[key] != null ? this.config[key] : ''
         }
-      }).replace(',1433', '');
+      }).replace(',1433', '')
 
       msnodesql.open(cfg, (err, tds) => {
         if (err) {

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -533,8 +533,8 @@ class Request extends base.Request {
               message: msg.message,
               number: msg.code,
               state: msg.sqlstate,
-              class: msg.class,
-              lineNumber: msg.lineNumber,
+              class: msg.class || 0,
+              lineNumber: msg.lineNumber || 0,
               serverName: msg.serverName,
               procName: msg.procName
           })

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -171,7 +171,7 @@ class ConnectionPool extends base.ConnectionPool {
           default:
             return this.config[key] != null ? this.config[key] : ''
         }
-      }).replace(',1433', '')
+      });
 
       msnodesql.open(cfg, (err, tds) => {
         if (err) {

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -14,8 +14,8 @@ const EMPTY_BUFFER = new Buffer(0)
 const JSON_COLUMN_ID = 'JSON_F52E2B61-18A1-11d1-B105-00805F49916B'
 const XML_COLUMN_ID = 'XML_F52E2B61-18A1-11d1-B105-00805F49916B'
 
-const CONNECTION_STRING_PORT = 'Driver={SQL Server Native Client 11.0};Server={#{server},#{port}};Database={#{database}};Uid={#{user}};Pwd={#{password}};Trusted_Connection={#{trusted}};'
-const CONNECTION_STRING_NAMED_INSTANCE = 'Driver={SQL Server Native Client 11.0};Server={#{server}\\#{instance}};Database={#{database}};Uid={#{user}};Pwd={#{password}};Trusted_Connection={#{trusted}};'
+const CONNECTION_STRING_PORT = 'Driver=SQL Server Native Client 11.0;Server=#{server},#{port};Database=#{database};Uid=#{user};Pwd=#{password};Trusted_Connection=#{trusted};'
+const CONNECTION_STRING_NAMED_INSTANCE = 'Driver=SQL Server Native Client 11.0;Server=#{server}\\#{instance};Database=#{database};Uid=#{user};Pwd=#{password};Trusted_Connection=#{trusted};'
 
 const castParameter = function (value, type) {
   if (value == null) {
@@ -171,7 +171,7 @@ class ConnectionPool extends base.ConnectionPool {
           default:
             return this.config[key] != null ? this.config[key] : ''
         }
-      })
+      }).replace(',1433', '');
 
       msnodesql.open(cfg, (err, tds) => {
         if (err) {

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -530,13 +530,13 @@ class Request extends base.Request {
           }
 
           this.emit('info', {
-              message: msg.message,
-              number: msg.code,
-              state: msg.sqlstate,
-              class: msg.class || 0,
-              lineNumber: msg.lineNumber || 0,
-              serverName: msg.serverName,
-              procName: msg.procName
+            message: msg.message,
+            number: msg.code,
+            state: msg.sqlstate,
+            class: msg.class || 0,
+            lineNumber: msg.lineNumber || 0,
+            serverName: msg.serverName,
+            procName: msg.procName
           })
         })
 

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -524,6 +524,22 @@ class Request extends base.Request {
           rowsAffected.push(count)
         })
 
+        req.on('info', msg => {
+          if ((/^\[Microsoft\]\[SQL Server Native Client 11\.0\](?:\[SQL Server\])?([\s\S]*)$/).exec(msg.message)) {
+            msg.message = RegExp.$1
+          }
+
+          this.emit('info', {
+              message: msg.message,
+              number: msg.code,
+              state: msg.sqlstate,
+              class: msg.class,
+              lineNumber: msg.lineNumber,
+              serverName: msg.serverName,
+              procName: msg.procName
+          })
+        })
+
         req.once('error', err => {
           if ((typeof err.sqlstate === 'string') && (err.sqlstate.toLowerCase() === '08s01')) {
             connection.hasError = true


### PR DESCRIPTION
Add event handler to subscribe to msnodesqlv8 info event and dispatch through node-mssql request.  Also when providing an object of arguments to build the connection string, the resulting connection string ends in this format:  

```
Driver={SQL Server Native Client 11.0};Server={localhost,1433};Database={MyDatabase};Uid={};Pwd={};Trusted_Connection={Yes};
```
The remaining brackets cause the connection string to be invalid. Also replaced ,1433 from the connection string if using the default port.

Usage example:

```
req.on('info', infoMessage => {
  console.log(infoMessage.message); // Could be PRINT message, Rows affected, statistics, time etc
});
```