### PR TITLE
Fixed issue where the encrypt option was getting ignored

### DIFF
--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -14,8 +14,8 @@ const EMPTY_BUFFER = new Buffer(0)
 const JSON_COLUMN_ID = 'JSON_F52E2B61-18A1-11d1-B105-00805F49916B'
 const XML_COLUMN_ID = 'XML_F52E2B61-18A1-11d1-B105-00805F49916B'
 
-const CONNECTION_STRING_PORT = 'Driver={SQL Server Native Client 11.0};Server={#{server},#{port}};Database={#{database}};Uid={#{user}};Pwd={#{password}};Trusted_Connection={#{trusted}};'
-const CONNECTION_STRING_NAMED_INSTANCE = 'Driver={SQL Server Native Client 11.0};Server={#{server}\\#{instance}};Database={#{database}};Uid={#{user}};Pwd={#{password}};Trusted_Connection={#{trusted}};'
+const CONNECTION_STRING_PORT = 'Driver={SQL Server Native Client 11.0};Server={#{server},#{port}};Database={#{database}};Uid={#{user}};Pwd={#{password}};Trusted_Connection={#{trusted}};Encrypt={#{encrypt}};'
+const CONNECTION_STRING_NAMED_INSTANCE = 'Driver={SQL Server Native Client 11.0};Server={#{server}\\#{instance}};Database={#{database}};Uid={#{user}};Pwd={#{password}};Trusted_Connection={#{trusted}};Encrypt={#{encrypt}};'
 
 const castParameter = function (value, type) {
   if (value == null) {
@@ -168,6 +168,8 @@ class ConnectionPool extends base.ConnectionPool {
             return this.config.options.instanceName
           case 'trusted':
             return this.config.options.trustedConnection ? 'Yes' : 'No'
+          case 'encrypt':
+            return this.config.options.encrypt ? 'Yes' : 'No'
           default:
             return this.config[key] != null ? this.config[key] : ''
         }


### PR DESCRIPTION
I noticed that while using a connection pool and the msnodesqlv8 driver that my `options: { encrypt: true }` setting was getting ignored and the connection was still happening in plain text without any notification or warning. I observed this while inspecting the packets with Wireshark.

I believe the following code resolves the issue. I'm not super familiar with the code base so this may not be the best solution and edits (or new pull requests) by anyone are welcomed.