### PR TITLE
Fix connections in the pool depleting due to unfulfilled Promises and timeouts

### DIFF
--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -231,8 +231,10 @@ class ConnectionPool extends base.ConnectionPool {
       IDS.add(tedious, 'Connection')
       debug('pool(%d): connection #%d created', IDS.get(this), IDS.get(tedious))
       debug('connection(%d): establishing', IDS.get(tedious))
+      const emittedConnectEvent = false
 
       tedious.once('connect', err => {
+        emittedConnectEvent = true
         if (err) {
           err = new base.ConnectionError(err)
           return reject(err)
@@ -241,6 +243,12 @@ class ConnectionPool extends base.ConnectionPool {
         debug('connection(%d): established', IDS.get(tedious))
         resolve(tedious)
       })
+
+      setTimeout(() => {
+        if (!emittedConnectEvent) {
+          reject(new base.ConnectionError('Tedious connection timed out after 10 seconds'))
+        }
+      }, 10 * 1000)
 
       tedious.on('error', err => {
         if (err.code === 'ESOCKET') {

--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -231,10 +231,8 @@ class ConnectionPool extends base.ConnectionPool {
       IDS.add(tedious, 'Connection')
       debug('pool(%d): connection #%d created', IDS.get(this), IDS.get(tedious))
       debug('connection(%d): establishing', IDS.get(tedious))
-      let emittedConnectEvent = false
 
       tedious.once('connect', err => {
-        emittedConnectEvent = true
         if (err) {
           err = new base.ConnectionError(err)
           return reject(err)
@@ -243,12 +241,6 @@ class ConnectionPool extends base.ConnectionPool {
         debug('connection(%d): established', IDS.get(tedious))
         resolve(tedious)
       })
-
-      setTimeout(() => {
-        if (!emittedConnectEvent) {
-          reject(new base.ConnectionError('Tedious connection timed out after options.connectTimeout'))
-        }
-      }, cfg.options.connectTimeout)
 
       tedious.on('error', err => {
         if (err.code === 'ESOCKET') {

--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -246,9 +246,9 @@ class ConnectionPool extends base.ConnectionPool {
 
       setTimeout(() => {
         if (!emittedConnectEvent) {
-          reject(new base.ConnectionError('Tedious connection timed out after 10 seconds'))
+          reject(new base.ConnectionError('Tedious connection timed out after options.connectTimeout'))
         }
-      }, 10 * 1000)
+      }, cfg.options.connectTimeout)
 
       tedious.on('error', err => {
         if (err.code === 'ESOCKET') {

--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -253,10 +253,12 @@ class ConnectionPool extends base.ConnectionPool {
       tedious.on('error', err => {
         if (err.code === 'ESOCKET') {
           tedious.hasError = true
+          reject(err)
           return
         }
 
         this.emit('error', err)
+        reject(err)
       })
 
       if (this.config.debug) {

--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -231,7 +231,7 @@ class ConnectionPool extends base.ConnectionPool {
       IDS.add(tedious, 'Connection')
       debug('pool(%d): connection #%d created', IDS.get(this), IDS.get(tedious))
       debug('connection(%d): establishing', IDS.get(tedious))
-      const emittedConnectEvent = false
+      let emittedConnectEvent = false
 
       tedious.once('connect', err => {
         emittedConnectEvent = true


### PR DESCRIPTION
Fixes #610
Closes #671

The number of available connections will routinely, gradually reduce to 0 over a period of hours. This seems to be prevalent on Azure hosted SQL Server instances.

We've spent a few weeks monitoring the problem and logging out connection pool metrics - the number of available connections (that can be loaned), the number of pool factory create operations (resolves to `_poolCreate` in this library), and so on...

```json
{"pool_all_objects_size":"9","potentially_allocable_resource_count":"10","threshold":"10","pool_reported_size":"10","available_connections":"9","factory_create_operations":"1"}
```

Unless you're monitoring connection metrics yourself, the problem will manifest when you see EREQUEST errors. We believe this to be due to the generic pool library being unable to loan a connection to a borrower, as **the "count" calculation also takes into account the number of factory create operations in progress:** https://github.com/coopernurse/node-pool/blob/master/lib/Pool.js#L638-L647

This means that while you may have a pool max size of 10, you could have 10 factory create operations in progress, resulting in 0 usable connections. When node-pool evaluates whether more connections need to be created, it won't create any due to the above functionality: https://github.com/coopernurse/node-pool/blob/master/lib/Pool.js#L332-L340

In master as of now, the `_poolCreate` method does not _always_ resolve upon an error, and additionally, there is currently no explicit timeout handling on establishing connections.

Therefore we now explicitly timeout if the `connectTimeout` config option is exceeded (thanks @jacqt), and reject the `_poolCreate` promise on any error. In practice this doesn't solve the ESOCKET problem with Azure (we're still working on them to get this fixed), but it should stop the catastrophic pool exhaustion.