### PR TITLE
Fixed default stream config

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1100,7 +1100,7 @@ class Request extends EventEmitter {
    */
 
   batch (batch, callback) {
-    if (this.stream == null && this.connection) this.stream = this.connection.config.stream
+    if (this.stream == null && this.parent) this.stream = this.parent.config.stream
     this.rowsAffected = 0
 
     if (typeof callback === 'function') {
@@ -1163,11 +1163,11 @@ class Request extends EventEmitter {
    */
 
   _batch (batch, callback) {
-    if (!this.connection) {
+    if (!this.parent) {
       return setImmediate(callback, new RequestError('No connection is specified for that request.', 'ENOCONN'))
     }
 
-    if (!this.connection.connected) {
+    if (!this.parent.connected) {
       return setImmediate(callback, new ConnectionError('Connection is closed.', 'ECONNCLOSED'))
     }
 
@@ -1184,7 +1184,7 @@ class Request extends EventEmitter {
    */
 
   bulk (table, callback) {
-    if (this.stream == null && this.connection) this.stream = this.connection.config.stream
+    if (this.stream == null && this.parent) this.stream = this.parent.config.stream
 
     if (this.stream || typeof callback === 'function') {
       this._bulk(table, (err, rowsAffected) => {
@@ -1259,7 +1259,7 @@ class Request extends EventEmitter {
    */
 
   query (command, callback) {
-    if (this.stream == null && this.connection) this.stream = this.connection.config.stream
+    if (this.stream == null && this.parent) this.stream = this.parent.config.stream
     this.rowsAffected = 0
 
     if (typeof callback === 'function') {
@@ -1343,7 +1343,7 @@ class Request extends EventEmitter {
    */
 
   execute (command, callback) {
-    if (this.stream == null && this.connection) this.stream = this.connection.config.stream
+    if (this.stream == null && this.parent) this.stream = this.parent.config.stream
     this.rowsAffected = 0
 
     if (typeof callback === 'function') {

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -5,6 +5,7 @@
 const sql = require('../../')
 const assert = require('assert')
 const cs = require('../../lib/connectionstring')
+const base = require('../../lib/base')
 
 describe('Connection String', () => {
   it('Connection String #1', done => {
@@ -160,6 +161,27 @@ describe('Unit', () => {
     assert.strictEqual(t.declare(), 'create table [#mytemptable] ([a] int, [b] tinyint null, [c] tinyint not null, constraint PK_mytemptable primary key (a, c))')
 
     return done()
+  })
+
+  it('Request uses ConnectionPool\'s stream config value by default', () => {
+    const originalDriver = base.driver
+    base.driver.Request = base.Request
+    const connectionPool = new base.ConnectionPool({ stream: true })
+    let request = connectionPool.request()
+    connectionPool.on('error', () => {})
+    request.on('error', () => {})
+    try {
+      request.query('this will error', () => {})
+    } catch (e) {}
+    assert.strictEqual(request.stream, true)
+    request = connectionPool.request()
+    request.stream = false
+    request.on('error', () => {})
+    try {
+      request.query('this will error', () => {})
+    } catch (e) {}
+    assert.strictEqual(request.stream, false)
+    base.driver = originalDriver
   })
 
   it('custom promise library', done => {


### PR DESCRIPTION
- Request now honor's its parent's stream config if no config is set on the request itself
- Added test to confirm behavior

The test I wrote is a little janky, but I didn't immediately see a cleaner way to implement it without a lot of effort.