### PR TITLE
Return the _poolDestroy promise before connecting again

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -240,14 +240,14 @@ class ConnectionPool extends EventEmitter {
     this._connecting = true
     debug('pool(%d): connecting', IDS.get(this))
 
-    // create one testing connection to check if everything is ok
+    // create one test connection to check if everything is ok
     this._poolCreate().then((connection) => {
       debug('pool(%d): connected', IDS.get(this))
 
       return this._poolDestroy(connection).then(() => {
         if (!this._connecting) {
-          // close was called before connection was established
-          return // exit silently
+          debug('pool(%d): not connecting, exiting silently (was close called before connection established?)', IDS.get(this))
+          return
         }
 
         // prepare pool

--- a/lib/base.js
+++ b/lib/base.js
@@ -244,32 +244,33 @@ class ConnectionPool extends EventEmitter {
     this._poolCreate().then((connection) => {
       debug('pool(%d): connected', IDS.get(this))
 
-      this._poolDestroy(connection)
-      if (!this._connecting) {
-        // close was called before connection was established
-        return // exit silently
-      }
+      return this._poolDestroy(connection).then( () =>{
+        if (!this._connecting) {
+          // close was called before connection was established
+          return // exit silently
+        }
 
-      // prepare pool
-      this.pool = gp.createPool({
-        create: this._poolCreate.bind(this),
-        validate: this._poolValidate.bind(this),
-        destroy: this._poolDestroy.bind(this)
-      }, Object.assign({
-        max: 10,
-        min: 0,
-        evictionRunIntervalMillis: 1000,
-        idleTimeoutMillis: 30000,
-        testOnBorrow: true
-      }, this.config.pool))
+        // prepare pool
+        this.pool = gp.createPool({
+          create: this._poolCreate.bind(this),
+          validate: this._poolValidate.bind(this),
+          destroy: this._poolDestroy.bind(this)
+        }, Object.assign({
+          max: 10,
+          min: 0,
+          evictionRunIntervalMillis: 1000,
+          idleTimeoutMillis: 30000,
+          testOnBorrow: true
+        }, this.config.pool))
 
-      this.pool.on('factoryCreateError', this.emit.bind(this, 'error'))
-      this.pool.on('factoryDestroyError', this.emit.bind(this, 'error'))
+        this.pool.on('factoryCreateError', this.emit.bind(this, 'error'))
+        this.pool.on('factoryDestroyError', this.emit.bind(this, 'error'))
 
-      this._connecting = false
-      this._connected = true
+        this._connecting = false
+        this._connected = true
 
-      callback(null)
+        callback(null)
+      })
     }).catch(err => {
       this._connecting = false
       callback(err)

--- a/lib/base.js
+++ b/lib/base.js
@@ -244,7 +244,7 @@ class ConnectionPool extends EventEmitter {
     this._poolCreate().then((connection) => {
       debug('pool(%d): connected', IDS.get(this))
 
-      return this._poolDestroy(connection).then( () =>{
+      return this._poolDestroy(connection).then(() => {
         if (!this._connecting) {
           // close was called before connection was established
           return // exit silently


### PR DESCRIPTION
Fixes #696 

this._poolDestroy returns a promise that gets orphaned. Instead of just continuing, wait for the Promise from the test connection's poolDestroy to return, then do the pool creation.