### PR TITLE
Update Tedious dependency to 2.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1588,7 +1588,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -1857,9 +1857,9 @@
       }
     },
     "tedious": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-2.6.4.tgz",
-      "integrity": "sha512-upFZB4QahZydPIV2VK3H/bz8Fsq5FSjqbxDbhhp1c/66ZJB1qCk5p1cXi2p/VUOgAYbmAzVObTg5kaVvmeyN+Q==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-2.7.1.tgz",
+      "integrity": "sha512-u3ciATGm5byim91b3+c3MVTvY1zKjDmhUhnBQZXKymT2Vb9w322dziPQY6MhBNyBEcNONPsAMR+7/Uub7NYABQ==",
       "requires": {
         "babel-runtime": "^6.26.0",
         "big-number": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "generic-pool": "^3.4.2",
-    "tedious": "^2.6.4"
+    "tedious": "^2.7.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",


### PR DESCRIPTION
This just bumps us to a BC update containing bugfixes: https://github.com/tediousjs/tedious/pull/769.

In theory this library could be upgraded to also drop Node v4 and support Tedious 3.0.

Closes #711
Fixes #470