### PR TITLE
Appveyor improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
   "scripts": {
     "test": "npm run lint && npm run test-unit",
     "lint": "standard",
-    "test-unit": "node_modules/.bin/mocha test/common/unit.js",
-    "test-tedious": "node_modules/.bin/mocha test/tedious",
-    "test-msnodesqlv8": "node_modules/.bin/mocha test/msnodesqlv8",
-    "test-cli": "node_modules/.bin/mocha test/common/cli.js"
+    "test-unit": "node_modules/.bin/mocha -t 15000 test/common/unit.js",
+    "test-tedious": "node_modules/.bin/mocha -t 15000 test/tedious",
+    "test-msnodesqlv8": "node_modules/.bin/mocha -t 15000 test/msnodesqlv8",
+    "test-cli": "node_modules/.bin/mocha -t 15000 test/common/cli.js"
   },
   "bin": {
     "mssql": "./bin/mssql"


### PR DESCRIPTION
I'm attempting to get AppVeyor builds passing more consistently.

I noticed that quite a few test in the suite can take 4000ms which is uncomfortably close to the 5000ms timeout.

I expect that many of the failures we are seeing on appveyor are because they are taking over the 5000ms limit for tests to complete.