### PR TITLE
If parseJSON is true and chunksBuffer is empty, set row result to null

### DIFF
--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -1008,7 +1008,11 @@ class Request extends base.Request {
           if (isChunkedRecordset) {
             if (columns[JSON_COLUMN_ID] && config.parseJSON === true) {
               try {
-                row = JSON.parse(chunksBuffer.join(''))
+                if (chunksBuffer.length === 0) {
+                  row = null
+                } else {
+                  row = JSON.parse(chunksBuffer.join(''))
+                }
               } catch (ex) {
                 row = null
                 const ex2 = new base.RequestError(new Error(`Failed to parse incoming JSON. ${ex.message}`), 'EJSON')


### PR DESCRIPTION
Fix JSON parsing error for empty value.

Closes #714 