### PR TITLE
Reduce package size - whitelist with files prop

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-node_modules
-.DS_Store
-.vscode
-/test.js
-/test

--- a/package.json
+++ b/package.json
@@ -37,6 +37,12 @@
   "engines": {
     "node": ">=4"
   },
+  "files": [
+    "lib/",
+    "bin/",
+    "*.js",
+    "*.md"
+  ],
   "scripts": {
     "test": "npm run lint && npm run test-unit",
     "lint": "standard",


### PR DESCRIPTION
This replaces `.npmignore` with a whitelist of files and shaves around 85kb off the package download size.