### PR TITLE
Passing encrypt option from mssql connection options to tedious options

### DIFF
--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -198,7 +198,7 @@ class ConnectionPool extends base.ConnectionPool {
         password: this.config.password,
         server: this.config.server,
         options: Object.assign({
-          encrypt: typeof this.config.encrypt === 'boolean' ? this.config.encrypt : false,
+          encrypt: typeof this.config.encrypt === 'boolean' ? this.config.encrypt : false
         }, this.config.options),
         domain: this.config.domain
       }

--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -210,6 +210,7 @@ class ConnectionPool extends base.ConnectionPool {
       cfg.options.rowCollectionOnRequestCompletion = false
       cfg.options.useColumnNames = false
       cfg.options.appName = cfg.options.appName || 'node-mssql'
+      cfg.options.encrypt = this.config.encrypt != null ? this.config.encrypt : true
 
       // tedious always connect via tcp when port is specified
       if (cfg.options.instanceName) delete cfg.options.port

--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -197,7 +197,9 @@ class ConnectionPool extends base.ConnectionPool {
         userName: this.config.user,
         password: this.config.password,
         server: this.config.server,
-        options: Object.assign({}, this.config.options),
+        options: Object.assign({
+          encrypt: typeof this.config.encrypt === 'boolean' ? this.config.encrypt : false,
+        }, this.config.options),
         domain: this.config.domain
       }
 
@@ -210,7 +212,6 @@ class ConnectionPool extends base.ConnectionPool {
       cfg.options.rowCollectionOnRequestCompletion = false
       cfg.options.useColumnNames = false
       cfg.options.appName = cfg.options.appName || 'node-mssql'
-      cfg.options.encrypt = this.config.encrypt != null ? this.config.encrypt : true
 
       // tedious always connect via tcp when port is specified
       if (cfg.options.instanceName) delete cfg.options.port


### PR DESCRIPTION
What this does:
When specifying the encrypt option in mssql connection options, the option is now passed to the tedious connection options.