### PR TITLE
Interpret Connection Timeout in seconds, not milliseconds

### DIFF
--- a/lib/connectionstring.js
+++ b/lib/connectionstring.js
@@ -235,7 +235,7 @@ const resolveConnectionString = function (string, driver) {
     config.options.useUTC = utc === 'true' || utc === 'yes' || utc === '1'
   }
   if (config.connectionTimeout != null) {
-    config.connectionTimeout = parseInt(config.connectionTimeout, 10)
+    config.connectionTimeout = parseInt(config.connectionTimeout, 10) * 1000
   }
   if (config.requestTimeout != null) {
     config.requestTimeout = parseInt(config.requestTimeout, 10)

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -62,7 +62,7 @@ describe('Connection String', () => {
     return done()
   })
 
-  return it('Connection String #6 (multiSubnetFailover)', done => {
+  it('Connection String #6 (multiSubnetFailover)', done => {
     let cfg = cs.resolve('Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd;MultiSubnetFailover=True')
 
     assert.strictEqual(cfg.options.multiSubnetFailover, true)
@@ -71,6 +71,18 @@ describe('Connection String', () => {
     assert.strictEqual(cfg.database, 'testdb')
     assert.strictEqual(cfg.server, '192.168.0.1')
     assert.strictEqual(cfg.port, undefined)
+
+    return done()
+  })
+
+  return it('Connection String #7 (connection timeout)', done => {
+    let cfg = cs.resolve('Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd;Connection Timeout=30')
+    assert.strictEqual(cfg.user, 'testuser')
+    assert.strictEqual(cfg.password, 'testpwd')
+    assert.strictEqual(cfg.database, 'testdb')
+    assert.strictEqual(cfg.server, '192.168.0.1')
+    assert.strictEqual(cfg.port, undefined)
+    assert.strictEqual(cfg.connectionTimeout, 30000)
 
     return done()
   })


### PR DESCRIPTION
This PR implements a shift from interpreting `Connection Timeout` in milliseconds, to interpreting it in seconds, when it comes from a connection string, as an attempt to fix #741.

Since this is a breaking change, it might be nice to expose some flag that can toggle this behavior, so the old behavior is still available for users who depend on it; so far nothing in that direction has been added.