### PR TITLE
acquireTimeoutMillis addition to confg.pool

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -258,6 +258,7 @@ class ConnectionPool extends EventEmitter {
         }, Object.assign({
           max: 10,
           min: 0,
+          acquireTimeoutMillis: this.config.connectionTimeout || 15000,
           evictionRunIntervalMillis: 1000,
           idleTimeoutMillis: 30000,
           testOnBorrow: true


### PR DESCRIPTION
What this does:
sets a default value for confg.pool.acquireTimeoutMillis which in turn enables a Promise.Reject when a connection is lost after a previous successful connection. There is still a unhandled rejection at the tedious driver level.


