### PR TITLE
Bump generic-pool to 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -967,9 +967,9 @@
       "dev": true
     },
     "generic-pool": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.2.tgz",
-      "integrity": "sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.6.0.tgz",
+      "integrity": "sha512-9tRjIJzgW+ZyYeFBhfLRUefnQwF+IFfEsUkdZB5o75/gb4OZWnYb4ZjPcZc1bl9ofhWCN2rGhXa0SQwF64jTLw=="
     },
     "get-stdin": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^3.2.6",
-    "generic-pool": "^3.4.2",
+    "generic-pool": "^3.6.0",
     "tedious": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
What this does:

Bumping the `generic-pool` dependency as we've had a couple of phantom connection issues that appear to be resolved in this release, see:

- https://github.com/coopernurse/node-pool/issues/159
- https://github.com/coopernurse/node-pool/pull/250
- https://github.com/tediousjs/node-mssql/issues/457#issuecomment-450147477
- https://github.com/typeorm/typeorm/pull/3327

fixes #457 (again)

---

https://github.com/coopernurse/node-pool/compare/v3.4.2...v3.6.0