### PR TITLE
Global connection improvements

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v6.0.0 (2019-0?-??)
 -------------------
 [new] Added `healthy` flag to the pool to help determine if the pool is safe to use or not ([#816](https://github.com/tediousjs/node-mssql/pull/816))
 [new] Invalid isolation levels passed to transactions will now throw an error
+[change] Closing the global connection by reference will now cleanup the internally managed globalConnection
 [change] Upgraded tedious to v6 ([#818](https://github.com/tediousjs/node-mssql/pull/818))
 [change] Remove references to deprecated `TYPES.Null` from tedious
 [change] `options.encrypt` is now set to true by default

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v6.0.0 (2019-0?-??)
 -------------------
 [new] Added `healthy` flag to the pool to help determine if the pool is safe to use or not ([#816](https://github.com/tediousjs/node-mssql/pull/816))
 [new] Invalid isolation levels passed to transactions will now throw an error
+[new] Calls to the global `connect` function will return the global connection if it exists
 [change] Closing the global connection by reference will now cleanup the internally managed globalConnection
 [change] Upgraded tedious to v6 ([#818](https://github.com/tediousjs/node-mssql/pull/818))
 [change] Remove references to deprecated `TYPES.Null` from tedious

--- a/lib/base.js
+++ b/lib/base.js
@@ -1743,11 +1743,13 @@ for (let key in TYPES) {
  *
  * @param {Object|String} config Connection configuration object or connection string.
  * @param {basicCallback} [callback] A callback which is called after connection has established, or an error has occurred. If omited, method returns Promise.
- * @return {ConnectionPool|Promise}
+ * @return {Promise.<ConnectionPool>}
  */
 
 module.exports.exports.connect = function connect (config, callback) {
-  if (globalConnection) throw new Error('Global connection already exists. Call sql.close() first.')
+  if (globalConnection) {
+    return PromiseLibrary.resolve(globalConnection)
+  }
   globalConnection = new driver.ConnectionPool(config)
 
   for (let event in globalConnectionHandlers) {

--- a/lib/base.js
+++ b/lib/base.js
@@ -1756,6 +1756,31 @@ module.exports.exports.connect = function connect (config, callback) {
     }
   }
 
+  const ogClose = globalConnection.close
+
+  function globalClose (callback) {
+    // remove event handlers from the global connection
+    for (let event in globalConnectionHandlers) {
+      for (let i = 0, l = globalConnectionHandlers[event].length; i < l; i++) {
+        this.removeListener(event, globalConnectionHandlers[event][i])
+      }
+    }
+
+    // attach error handler to prevent process crash in case of error
+    this.on('error', err => {
+      if (globalConnectionHandlers['error']) {
+        for (let i = 0, l = globalConnectionHandlers['error'].length; i < l; i++) {
+          globalConnectionHandlers['error'][i].call(this, err)
+        }
+      }
+    })
+
+    globalConnection = null
+    return ogClose.call(this, callback)
+  }
+
+  globalConnection.close = globalClose.bind(globalConnection)
+
   return globalConnection.connect(callback)
 }
 
@@ -1768,22 +1793,6 @@ module.exports.exports.connect = function connect (config, callback) {
 
 module.exports.exports.close = function close (callback) {
   if (globalConnection) {
-    // remove event handlers from the global connection
-    for (let event in globalConnectionHandlers) {
-      for (let i = 0, l = globalConnectionHandlers[event].length; i < l; i++) {
-        globalConnection.removeListener(event, globalConnectionHandlers[event][i])
-      }
-    }
-
-    // attach error handler to prevent process crash in case of error
-    globalConnection.on('error', err => {
-      if (globalConnectionHandlers['error']) {
-        for (let i = 0, l = globalConnectionHandlers['error'].length; i < l; i++) {
-          globalConnectionHandlers['error'][i].call(globalConnection, err)
-        }
-      }
-    })
-
     const gc = globalConnection
     globalConnection = null
     return gc.close(callback)


### PR DESCRIPTION
At the moment if you have code that calls `close` on the global connection by reference (rather than directly through `mssql.close`) then the global connection reference remains and you can't reconnect.

example:

```js
const mssql = require('mssql');

mssql.connect(config).then((connection) => {
    connection.on('error', (err) => {
        // this won't clean up the global connection reference
        connection.close();
    });
    return connection;
});
```

This fix allows the global connection to be replaced if the connection is closed.

At the moment if you lose reference to the global connection there's no way to get it back. This change allows you to call `mssql.connect()` again and have the existing connection returned. It is naive and won't compare the connection configs. The global connection should not be used for anything but the most basic requirements.

Q: Should we force a call to `close()` to remove the event listeners and other references? **yes**

closes #616 