### PR TITLE
NEW Add backing off to failed factoryCreate for node-pool

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -250,9 +250,19 @@ class ConnectionPool extends EventEmitter {
           return
         }
 
+        let createAttempt = 0
+
+        function create () {
+          // Create an "ID" to help track debugging messages
+          const createId = createAttempt++
+          const timeout = this.config.pool ? this.config.pool.acquireTimeoutMillis : undefined
+
+          return this._poolCreateRetry(createId, 0, timeout)
+        }
+
         // prepare pool
         this.pool = gp.createPool({
-          create: this._poolCreate.bind(this),
+          create: create.bind(this),
           validate: this._poolValidate.bind(this),
           destroy: this._poolDestroy.bind(this)
         }, Object.assign({
@@ -274,6 +284,40 @@ class ConnectionPool extends EventEmitter {
     }).catch(err => {
       this._connecting = false
       callback(err)
+    })
+  }
+
+  _poolCreateRetry (createId, retryCount, timeout) {
+    const self = this
+    let backoff
+    debug('pool(%d): attempting to create connection resource(%d), attempt #%d', IDS.get(this), createId, retryCount)
+    // increment our retry count on error and calculate a new backoff
+    retryCount++
+    return this._poolCreate().catch((e) => {
+      // don't bother calculating backoffs > 8, this caps us at ~30s per retry
+      backoff = retryCount > 8 ? backoff : Math.pow(2, retryCount) * 100
+      if (typeof timeout !== 'undefined') {
+        timeout -= backoff
+        if (timeout <= 0) {
+          throw e
+        }
+      }
+      return new Promise((resolve, reject) => {
+        // construct a timer-based promise to retry the connection attempt
+        const timer = setTimeout(() => {
+          debug('pool(%d): backoff timer complete resource(%d)', IDS.get(self), createId)
+          // if the connection has been closed, reject
+          if (!self.connecting && !self.connected) {
+            debug('pool(%d): pool closed while trying to acquire a connection resource(%d)', IDS.get(self), createId)
+            reject(new ConnectionError('Connection is closed.', 'ECONNCLOSED'))
+          } else {
+            resolve()
+          }
+        }, backoff)
+        // don't let this timer block node from exiting
+        timer.unref()
+        debug('pool(%d): failed to create connection resource(%d), retrying with backoff of %dms', IDS.get(self), createId, backoff)
+      }).then(this._poolCreateRetry.bind(this, createId, retryCount, timeout))
     })
   }
 
@@ -309,12 +353,11 @@ class ConnectionPool extends EventEmitter {
     if (!this.pool) return setImmediate(callback, null)
 
     const pool = this.pool
-    this.pool.drain().then(() => {
+    this.pool = null
+    pool.drain().then(() => {
       pool.clear()
       callback(null)
     })
-
-    this.pool = null
   }
 
   /**

--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -202,12 +202,16 @@ class ConnectionPool extends base.ConnectionPool {
 
   _poolValidate (tds) {
     return new base.Promise((resolve, reject) => {
-      resolve(!tds.hasError)
+      resolve(tds && !tds.hasError)
     })
   }
 
   _poolDestroy (tds) {
     return new base.Promise((resolve, reject) => {
+      if (!tds) {
+        resolve()
+        return
+      }
       debug('connection(%d): destroying', IDS.get(tds))
       tds.close()
       debug('connection(%d): destroyed', IDS.get(tds))

--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -271,12 +271,16 @@ class ConnectionPool extends base.ConnectionPool {
 
   _poolValidate (tedious) {
     return new base.Promise((resolve, reject) => {
-      resolve(!tedious.closed && !tedious.hasError)
+      resolve(tedious && !tedious.closed && !tedious.hasError)
     })
   }
 
   _poolDestroy (tedious) {
     return new base.Promise((resolve, reject) => {
+      if (!tedious) {
+        resolve()
+        return
+      }
       debug('connection(%d): destroying', IDS.get(tedious))
 
       tedious.once('end', () => {


### PR DESCRIPTION
What this does:
This is a potential fix to #805 

~~It's still work in progress as there are some `UnhandledPromiseRejectionWarning`s, which I'm trying to get to the bottom of.~~

Thoughts on this resolution would be appreciated

---

NB: It seems that there is a problem with generic-pool where it will continually attempt to create resources no matter what and there's not a lot we can do to resolve that.

Not only that, it will continue to attempt to create resources after `drain` is called (attempting to close the pool) - I think because they are already queued up.