### PR TITLE
 Added `healthy` flag to ConnectionPool

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 v6.0.0 (2019-0?-??)
 -------------------
+[new] Added `healthy` flag to the pool to help determine if the pool is safe to use or not ([#816](https://github.com/tediousjs/node-mssql/pull/816))
 [change] Upgraded tedious to v6 ([#818](https://github.com/tediousjs/node-mssql/pull/818))
 [change] `options.encrypt` is now set to true by default
 [change] Upgraded `debug` dependency to v4

--- a/lib/base.js
+++ b/lib/base.js
@@ -125,6 +125,7 @@ class ConnectionPool extends EventEmitter {
     this.config = config
     this._connected = false
     this._connecting = false
+    this._healthy = false
 
     if (typeof this.config === 'string') {
       try {
@@ -159,6 +160,10 @@ class ConnectionPool extends EventEmitter {
 
   get connecting () {
     return this._connecting
+  }
+
+  get healthy () {
+    return this._healthy
   }
 
   /**
@@ -247,6 +252,7 @@ class ConnectionPool extends EventEmitter {
     // create one test connection to check if everything is ok
     this._poolCreate().then((connection) => {
       debug('pool(%d): connected', IDS.get(this))
+      this._healthy = true
 
       this._poolDestroy(connection)
       if (!this._connecting) {
@@ -257,7 +263,17 @@ class ConnectionPool extends EventEmitter {
       // prepare pool
       this.pool = new tarn.Pool(
         Object.assign({
-          create: this._poolCreate.bind(this),
+          create: () => this._poolCreate()
+            .then(connection => {
+              this._healthy = true
+              return connection
+            })
+            .catch(err => {
+              if (this.pool.numUsed() + this.pool.numFree() <= 0) {
+                this._healthy = false
+              }
+              throw err
+            }),
           validate: this._poolValidate.bind(this),
           destroy: this._poolDestroy.bind(this),
           max: 10,


### PR DESCRIPTION
Branched from #808, as those changes are critical for us. We can rebase/resubmit another PR if/when #808 is merged.

- ConnectionPool starts out as healthy
- If the internal pools connections drop to 0, and a createPool call
fails, then the ConnectionPool will be flagged as unhealthy (healthy =
false)
- If an unhealthy ConnectionPool is able to successfully call
createPool, then the ConnectionPool will be reflagged as healthy
(healthy = true)
- This allows applications to decide how to deal with unhealthy
ConnectionPools (recreate, check for new config, failover, etc).