### PR TITLE
Add note about params of format `@p{n}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,8 @@ __Errors__ (synchronous)
 
 ---------------------------------------
 
+NB: Do not use parameters `@p{n}` as these are used by the internal drivers and cause a conflict.
+
 ### output (name, type, [value])
 
 Add an output parameter to the request.


### PR DESCRIPTION
Docs update. see #346 for context.