### PR TITLE
Remove references to remove TYPES.Null

### DIFF
--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -628,7 +628,7 @@ class Request extends base.Request {
             for (let name in batchLastRow) {
               let value = batchLastRow[name]
               if (name !== '___return___') {
-                output[name] = value === tds.TYPES.Null ? null : value
+                output[name] = value
               }
             }
           }
@@ -747,7 +747,7 @@ class Request extends base.Request {
         req.on('done', doneHandler) // done handlers are used in batches
 
         req.on('returnValue', (parameterName, value, metadata) => {
-          output[parameterName] = value === tds.TYPES.Null ? null : value
+          output[parameterName] = value
         })
 
         req.on('row', columns => {
@@ -1072,7 +1072,7 @@ class Request extends base.Request {
         })
 
         req.on('returnValue', (parameterName, value, metadata) => {
-          output[parameterName] = value === tds.TYPES.Null ? null : value
+          output[parameterName] = value
         })
 
         for (let name in this.parameters) {


### PR DESCRIPTION
What this does:

fixes #782 

According to https://github.com/tediousjs/tedious/pull/771 it's not even possible for SQL server to emit a `Null` type, so these lines won't do anything, it seems?