### PR TITLE
FIX _poolDestroy shouldnt return a promise

### DIFF
--- a/lib/msnodesqlv8.js
+++ b/lib/msnodesqlv8.js
@@ -205,16 +205,12 @@ class ConnectionPool extends base.ConnectionPool {
   }
 
   _poolDestroy (tds) {
-    return new base.Promise((resolve, reject) => {
-      if (!tds) {
-        resolve()
-        return
-      }
-      debug('connection(%d): destroying', IDS.get(tds))
-      tds.close()
-      debug('connection(%d): destroyed', IDS.get(tds))
-      resolve()
-    })
+    if (!tds) {
+      return
+    }
+    debug('connection(%d): destroying', IDS.get(tds))
+    tds.close()
+    debug('connection(%d): destroyed', IDS.get(tds))
   }
 }
 


### PR DESCRIPTION
What this does:

- `_poolDestroy` should not return a promise (see #808)

This was overlooked as part of the tarn upgrade