### PR TITLE
NEW Bulk loading of date fields attempts to cooerce date value

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ v6.0.0 (2019-0?-??)
 [new] Duplicate parameter names in queries/stored procedures will now throw an error
 [new] `replaceInput` and `replaceOutput` functions added to `Request` and `PreparedStatement` to facilitate replacing existing parameters
 [new] Calls to the global `connect` function will return the global connection if it exists
+[new] Bulk table inserts now attempt to coerce Date objects out of non Date values
 [change] Closing the global connection by reference will now cleanup the internally managed globalConnection
 [change] Upgraded tedious to v6 ([#818](https://github.com/tediousjs/node-mssql/pull/818))
 [change] Remove references to deprecated `TYPES.Null` from tedious

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Parts of the connection URI should be correctly URL encoded so that the URI can 
 * [pipe](#pipe-stream)
 * [query](#query-command-callback)
 * [batch](#batch-batch-callback)
-* [bulk](#bulk-table-callback)
+* [bulk](#bulk-table-options-callback)
 * [cancel](#cancel)
 
 ### Transactions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install
-  - npm install msnodesqlv8@0.6.6
+  - npm install msnodesqlv8@0.6.12
 
 cache:
   - node_modules

--- a/lib/table.js
+++ b/lib/table.js
@@ -54,6 +54,20 @@ Table.prototype._makeBulk = function _makeBulk () {
   for (let i = 0; i < this.columns.length; i++) {
     const col = this.columns[i]
     switch (col.type) {
+      case TYPES.DateTime:
+      case TYPES.DateTime2:
+        for (let j = 0; j < this.rows.length; j++) {
+          let dateValue = this.rows[j][i]
+          if (typeof dateValue === 'string' || typeof dateValue === 'number') {
+            let date = new Date(dateValue)
+            if (isNaN(date.getDate())) {
+              throw new TypeError('Invalid date value passed to bulk rows')
+            }
+            this.rows[j][i] = new Date(dateValue)
+          }
+        }
+        break
+
       case TYPES.Xml:
         col.type = TYPES.NVarChar(MAX).type
         break

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -469,6 +469,31 @@ module.exports = (sql, driver) => {
       }).catch(done)
     },
 
+    'bulk converts dates' (done) {
+      let t = new sql.Table('#bulkconverts')
+      t.create = true
+      t.columns.add('a', sql.Int, { nullable: false })
+      t.columns.add('b', sql.DateTime2, { nullable: true })
+      t.rows.add(1, new Date('2019-03-12T11:06:59.000Z'))
+      t.rows.add(2, '2019-03-12T11:06:59.000Z')
+      t.rows.add(3, 1552388819000)
+
+      let req = new TestRequest()
+      req.bulk(t).then(result => {
+        assert.strictEqual(result.rowsAffected, 3)
+
+        req = new sql.Request()
+        return req.batch(`select * from #bulkconverts`).then(result => {
+          assert.strictEqual(result.recordset.length, 3)
+          for (let i = 0; i < result.recordset.length; i++) {
+            assert.strictEqual(result.recordset[i].b.toISOString(), '2019-03-12T11:06:59.000Z')
+          }
+
+          done()
+        })
+      }).catch(done)
+    },
+
     'prepared statement' (done) {
       const ps = new TestPreparedStatement()
       ps.input('num', sql.Int)

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -110,7 +110,7 @@ describe('msnodesqlv8', function () {
     })
 
     it('bulk load (table)', done => TESTS['bulk load']('bulk_table', done))
-    it.skip('bulk load (temporary table) (not supported by msnodesqlv8)', done => TESTS['bulk load']('#anohter_bulk_table', done))
+    it('bulk load (temporary table)', done => TESTS['bulk load']('#anohter_bulk_table', done))
     it('bulk converts dates', done => TESTS['bulk converts dates'](done))
 
     after(done => sql.close(done))

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -111,6 +111,7 @@ describe('msnodesqlv8', function () {
 
     it('bulk load (table)', done => TESTS['bulk load']('bulk_table', done))
     it.skip('bulk load (temporary table) (not supported by msnodesqlv8)', done => TESTS['bulk load']('#anohter_bulk_table', done))
+    it('bulk converts dates', done => TESTS['bulk converts dates'](done))
 
     after(done => sql.close(done))
   })

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -121,6 +121,7 @@ describe('tedious', () => {
 
     it('bulk load (table)', done => TESTS['bulk load']('bulk_table', done))
     it('bulk load (temporary table)', done => TESTS['bulk load']('#anohter_bulk_table', done))
+    it('bulk converts dates', done => TESTS['bulk converts dates'](done))
 
     after(done => sql.close(done))
   })


### PR DESCRIPTION
What this does:

- fixes #278 
- Coerce non date object arguments to `DateTime` and `DateTime2` columns