### PR TITLE
Add test for url encoded values in connection URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ const sql = require('mssql')
 
 async () => {
     try {
+        // make sure that any items are correctly URL encoded in the connection string
         await sql.connect('mssql://username:password@localhost/database')
         const result = await sql.query`select * from mytable where id = ${value}`
         console.dir(result)
@@ -29,6 +30,8 @@ async () => {
 ```
 
 If you're on Windows Azure, add `?encrypt=true` to your connection string. See [docs](#configuration) to learn more.
+
+Parts of the connection URI should be correctly URL encoded so that the URI can be parsed correctly.
 
 ## Documentation
 

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -75,7 +75,7 @@ describe('Connection String', () => {
     return done()
   })
 
-  return it('Connection String #7 (connection timeout)', done => {
+  it('Connection String #7 (connection timeout)', done => {
     let cfg = cs.resolve('Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd;Connection Timeout=30')
     assert.strictEqual(cfg.user, 'testuser')
     assert.strictEqual(cfg.password, 'testpwd')
@@ -83,6 +83,18 @@ describe('Connection String', () => {
     assert.strictEqual(cfg.server, '192.168.0.1')
     assert.strictEqual(cfg.port, undefined)
     assert.strictEqual(cfg.connectionTimeout, 30000)
+
+    return done()
+  })
+
+  it('Connection String #8 (url encoding)', done => {
+    let cfg = cs.resolve('mssql://username:password%23@localhost:1433/database?encrypt=true')
+    assert.strictEqual(cfg.user, 'username')
+    assert.strictEqual(cfg.password, 'password#')
+    assert.strictEqual(cfg.database, 'database')
+    assert.strictEqual(cfg.server, 'localhost')
+    assert.strictEqual(cfg.port, 1433)
+    assert.strictEqual(cfg.options.encrypt, true)
 
     return done()
   })


### PR DESCRIPTION
What this does:

Proves URL encoding works for URI connection strings
