### PR TITLE
Add readOnlyIntent to connection string parsing

### DIFF
--- a/lib/connectionstring.js
+++ b/lib/connectionstring.js
@@ -226,6 +226,7 @@ const resolveConnectionString = function (string, driver) {
     requestTimeout: oror(parsed.requestTimeout, parsed['request timeout']),
     stream: stream === 'true' || stream === 'yes' || stream === '1',
     options: {
+      readOnlyIntent: parsed.applicationintent && parsed.applicationintent.toLowerCase() === 'readonly',
       encrypt: encrypt === 'true' || encrypt === 'yes' || encrypt === '1'
     }
   }

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -75,7 +75,7 @@ describe('Connection String', () => {
     return done()
   })
 
-  return it('Connection String #7 (connection timeout)', done => {
+  it('Connection String #7 (connection timeout)', done => {
     let cfg = cs.resolve('Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd;Connection Timeout=30')
     assert.strictEqual(cfg.user, 'testuser')
     assert.strictEqual(cfg.password, 'testpwd')
@@ -83,6 +83,20 @@ describe('Connection String', () => {
     assert.strictEqual(cfg.server, '192.168.0.1')
     assert.strictEqual(cfg.port, undefined)
     assert.strictEqual(cfg.connectionTimeout, 30000)
+
+    return done()
+  })
+
+  it('Pulls out read only ApplicationIntent', done => {
+    const cfg = cs.resolve('Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd;Connection Timeout=30;ApplicationIntent=ReadOnly')
+    assert.strictEqual(cfg.options.readOnlyIntent, true)
+
+    return done()
+  })
+
+  it('Pulls out read write ApplicationIntent', done => {
+    const cfg = cs.resolve('Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd;Connection Timeout=30;ApplicationIntent=ReadWrite')
+    assert.strictEqual(cfg.options.readOnlyIntent, false)
 
     return done()
   })


### PR DESCRIPTION
What this does:

Fixes #848 

Adds the ability to set readOnlyIntent via a connection string. Official docs: https://docs.microsoft.com/en-us/sql/relational-databases/native-client/applications/using-connection-string-keywords-with-sql-server-native-client?view=sql-server-2017