### PR TITLE
Fix some setImmediate() in base.ConnectionPool

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -130,7 +130,7 @@ class ConnectionPool extends EventEmitter {
         this.config = ConnectionString.resolve(config, driver.name)
       } catch (ex) {
         if (typeof callback === 'function') {
-          return callback(ex)
+          return setImmediate(callback, ex)
         }
         throw ex
       }
@@ -231,11 +231,11 @@ class ConnectionPool extends EventEmitter {
 
   _connect (callback) {
     if (this._connected) {
-      return callback(new ConnectionError('Database is already connected! Call close before connecting to different database.', 'EALREADYCONNECTED'))
+      return setImmediate(callback, new ConnectionError('Database is already connected! Call close before connecting to different database.', 'EALREADYCONNECTED'))
     }
 
     if (this._connecting) {
-      return callback(new ConnectionError('Already connecting to database! Call close before connecting to different database.', 'EALREADYCONNECTING'))
+      return setImmediate(callback, new ConnectionError('Already connecting to database! Call close before connecting to different database.', 'EALREADYCONNECTING'))
     }
 
     this._connecting = true


### PR DESCRIPTION
What this does: It ensures the callback in in the ConnectionPool constructor and in ConnectionPool._connect() are called async.