### PR TITLE
Add Node v12 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
 
 jobs:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - npm install
-  - IF "%nodejs_version%" == "10" (npm install msnodesqlv8@0.8.2) ELSE (npm install msnodesqlv8@0.6.12)
+  - IF %nodejs_version% GEQ 10 (npm install msnodesqlv8@0.8.2) ELSE (npm install msnodesqlv8@0.6.12)
 
 platform:
   - x86

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,14 @@ environment:
     - nodejs_version: "12"
 
 install:
-  - ps: Install-Product node $env:nodejs_version
+  # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - npm install
   - IF "%nodejs_version%" == "10" (npm install msnodesqlv8@0.8.2) ELSE (npm install msnodesqlv8@0.6.12)
+
+platform:
+  - x86
+  - x64
 
 cache:
   - node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"
+    - nodejs_version: "12"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
What this does:

Adds Node v12 to the build matrix for testing, also adds x86/x64 tests, although not sure if the latter is really needed in 2019 😉 