### PR TITLE
remove double date creation in _makeBulk

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -59,11 +59,11 @@ Table.prototype._makeBulk = function _makeBulk () {
         for (let j = 0; j < this.rows.length; j++) {
           let dateValue = this.rows[j][i]
           if (typeof dateValue === 'string' || typeof dateValue === 'number') {
-            let date = new Date(dateValue)
+            const date = new Date(dateValue)
             if (isNaN(date.getDate())) {
               throw new TypeError('Invalid date value passed to bulk rows')
             }
-            this.rows[j][i] = new Date(dateValue)
+            this.rows[j][i] = date
           }
         }
         break


### PR DESCRIPTION
What this does:
small fix for bulk ops; converted date already exists