### PR TITLE
Request.input should not allow 0 arguments

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1147,7 +1147,7 @@ class Request extends EventEmitter {
       throw new RequestError(`SQL injection warning for param '${name}'`, 'EINJECT')
     }
 
-    if (arguments.length <= 1) {
+    if (arguments.length < 2) {
       throw new RequestError('Invalid number of arguments. At least 2 arguments expected.', 'EARGS')
     } else if (arguments.length === 2) {
       value = type

--- a/lib/base.js
+++ b/lib/base.js
@@ -1147,7 +1147,7 @@ class Request extends EventEmitter {
       throw new RequestError(`SQL injection warning for param '${name}'`, 'EINJECT')
     }
 
-    if (arguments.length === 1) {
+    if (arguments.length <= 1) {
       throw new RequestError('Invalid number of arguments. At least 2 arguments expected.', 'EARGS')
     } else if (arguments.length === 2) {
       value = type


### PR DESCRIPTION
`Request.input` has a check at [L1150](https://github.com/tediousjs/node-mssql/blob/41f374105f048a5a4fc682b88bc0a431104fae89/lib/base.js#L1150) where it's supposed to ensure that at least two parameters are passed to the function, however it only checks `if (arguments.length === 1) {` and thus calling the function without any arguments passes this test throwing a TypeError at L1170 instead of an EARGS error like expected. [example](https://runkit.com/swant/mssql-request-input-doesn-t-throw-properly)

What this does: Changes behavour to throw if 1 or fewer arguments provided
