### PR TITLE
Correct Syntax Error in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ async () => {
     try {
         // make sure that any items are correctly URL encoded in the connection string
         await sql.connect('mssql://username:password@localhost/database')
-        const result = await sql.query`select * from mytable where id = ${value}`
+        const result = await sql.query(`select * from mytable where id = ${value}`)
         console.dir(result)
     } catch (err) {
         // ... error checks


### PR DESCRIPTION
Corrected minor Syntax error on line 24.by adding parentheses around function call.

What this does:
Makes a minor correction to the example function.