### PR TITLE
Fixes #891 - Bulk Insert for NVARCHAR(MAX) Fields

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -32,6 +32,7 @@ function Table (name) {
       column.name = name
       column.nullable = options.nullable
       column.primary = options.primary
+      column.length = options.length
 
       return this.push(column)
     }


### PR DESCRIPTION
What this does:
Fixes #891

Adds the ability to set length for an NVARCHAR(MAX) column, which was breaking while bulk insertion.