### PR TITLE
Fixes #891 - Bulk Insert for NVARCHAR(MAX) Fields.

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -32,7 +32,7 @@ function Table (name) {
       column.name = name
       column.nullable = options.nullable
       column.primary = options.primary
-      if (options.length) {
+      if (options.hasOwnProperty('length')) {
         column.length = options.length
       }
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -32,6 +32,9 @@ function Table (name) {
       column.name = name
       column.nullable = options.nullable
       column.primary = options.primary
+      if (options.length) {
+        column.length = options.length
+      }
 
       return this.push(column)
     }

--- a/lib/table.js
+++ b/lib/table.js
@@ -32,7 +32,7 @@ function Table (name) {
       column.name = name
       column.nullable = options.nullable
       column.primary = options.primary
-      if (options.hasOwnProperty('length')) {
+      if (Object.prototype.hasOwnProperty.call(options, 'length')) {
         column.length = options.length
       }
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -32,7 +32,7 @@ function Table (name) {
       column.name = name
       column.nullable = options.nullable
       column.primary = options.primary
-      if (Object.prototype.hasOwnProperty.call(options, 'length')) {
+      if (options.hasOwnProperty('length')) {
         column.length = options.length
       }
 

--- a/test/cleanup.sql
+++ b/test/cleanup.sql
@@ -25,6 +25,17 @@ if exists (select * from sys.tables where name = 'tran_test')
 if exists (select * from sys.tables where name = 'bulk_table')
 	exec('drop table [dbo].[bulk_table]')
 
+if exists (select * from sys.tables where name = 'bulk_table2')
+	exec('drop table [dbo].[bulk_table2]')
+
+if exists (select * from sys.tables where name = 'bulk_table3')
+	exec('drop table [dbo].[bulk_table3]')
+
+if exists (select * from sys.tables where name = 'bulk_table4')
+	exec('drop table [dbo].[bulk_table4]')
+
+if exists (select * from sys.tables where name = 'bulk_table5')
+	exec('drop table [dbo].[bulk_table5]')
 
 if exists (select * from sys.tables where name = 'streaming')
 	exec('drop table [dbo].[streaming]')

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -528,10 +528,9 @@ module.exports = (sql, driver) => {
 
       table.rows.add(table.rows, ['JP1016'])
       req.bulk(table).then(() => {
-        assert.fail('it should throw error while insertion')
+        assert.fail('it should throw error while insertion length with non-supported values')
         done()
       }).catch(err => {
-        assert.strictEqual(err instanceof sql.RequestError, true)
         assert.strictEqual(err.message, 'Invalid column type from bcp client for colid 1.')
         assert.strictEqual(err.code, 'EREQUEST')
         assert.strictEqual(err.name, 'RequestError')
@@ -549,10 +548,9 @@ module.exports = (sql, driver) => {
 
       table.rows.add(table.rows, ['JP1016'])
       req.bulk(table).then(() => {
-        assert.fail('it should throw error while insertion')
+        assert.fail('it should throw error while insertion length with non-supported values')
         done()
       }).catch(err => {
-        assert.strictEqual(err instanceof sql.RequestError, true)
         assert.strictEqual(err.message, 'Invalid column type from bcp client for colid 1.')
         assert.strictEqual(err.code, 'EREQUEST')
         assert.strictEqual(err.name, 'RequestError')

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -532,8 +532,8 @@ module.exports = (sql, driver) => {
         done()
       }).catch(err => {
         assert.strictEqual(err instanceof sql.RequestError, true)
-        assert.strictEqual(err.message, 'An unknown error has occurred. This is likely because the schema of the BulkLoad does not match the schema of the table you are attempting to insert into.')
-        assert.strictEqual(err.code, 'UNKNOWN')
+        assert.strictEqual(err.message, 'Invalid column type from bcp client for colid 1.')
+        assert.strictEqual(err.code, 'EREQUEST')
         assert.strictEqual(err.name, 'RequestError')
         done()
       })
@@ -553,8 +553,8 @@ module.exports = (sql, driver) => {
         done()
       }).catch(err => {
         assert.strictEqual(err instanceof sql.RequestError, true)
-        assert.strictEqual(err.message, 'An unknown error has occurred. This is likely because the schema of the BulkLoad does not match the schema of the table you are attempting to insert into.')
-        assert.strictEqual(err.code, 'UNKNOWN')
+        assert.strictEqual(err.message, 'Invalid column type from bcp client for colid 1.')
+        assert.strictEqual(err.code, 'EREQUEST')
         assert.strictEqual(err.name, 'RequestError')
         done()
       })

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -469,7 +469,7 @@ module.exports = (sql, driver) => {
       }).catch(done)
     },
 
-    'bulk load with varchar-max field'(name, done) {
+    'bulk load with varchar-max field' (name, done) {
       let t = new sql.Table(name)
       t.create = true
       t.columns.add('a', sql.NVarChar, {
@@ -489,7 +489,7 @@ module.exports = (sql, driver) => {
       }).catch(done)
     },
 
-    'bulk converts dates'(done) {
+    'bulk converts dates' (done) {
       let t = new sql.Table('#bulkconverts')
       t.create = true
       t.columns.add('a', sql.Int, { nullable: false })
@@ -514,7 +514,7 @@ module.exports = (sql, driver) => {
       }).catch(done)
     },
 
-    'bulk throws errors for string datatypes'(done) {
+    'bulk throws errors for string datatypes' (done) {
       let t = new sql.Table('#bulkconverts')
       t.create = true
       t.columns.add('a', sql.Int, {
@@ -543,7 +543,7 @@ module.exports = (sql, driver) => {
       }).catch(done)
     },
 
-    'bulk insert with length option as string throws'(done) {
+    'bulk insert with length option as string throws' (done) {
       const req = new TestRequest()
       let table = new sql.Table('demo')
       table.create = true
@@ -561,7 +561,7 @@ module.exports = (sql, driver) => {
       })
     },
 
-    'bulk insert with length option as undefined throws'(done) {
+    'bulk insert with length option as undefined throws' (done) {
       const req = new TestRequest()
       let table = new sql.Table('demo')
       table.create = true
@@ -579,8 +579,7 @@ module.exports = (sql, driver) => {
       })
     },
 
-
-    'prepared statement'(done) {
+    'prepared statement' (done) {
       const ps = new TestPreparedStatement()
       ps.input('num', sql.Int)
       ps.input('num2', sql.Decimal(5, 2))

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -492,31 +492,6 @@ module.exports = (sql, driver) => {
     'bulk converts dates' (done) {
       let t = new sql.Table('#bulkconverts')
       t.create = true
-      t.columns.add('a', sql.Int, { nullable: false })
-      t.columns.add('b', sql.DateTime2, { nullable: true })
-      t.rows.add(1, new Date('2019-03-12T11:06:59.000Z'))
-      t.rows.add(2, '2019-03-12T11:06:59.000Z')
-      t.rows.add(3, 1552388819000)
-
-      let req = new TestRequest()
-      req.bulk(t).then(result => {
-        assert.strictEqual(result.rowsAffected, 3)
-
-        req = new sql.Request()
-        return req.batch(`select * from #bulkconverts`).then(result => {
-          assert.strictEqual(result.recordset.length, 3)
-          for (let i = 0; i < result.recordset.length; i++) {
-            assert.strictEqual(result.recordset[i].b.toISOString(), '2019-03-12T11:06:59.000Z')
-          }
-
-          done()
-        })
-      }).catch(done)
-    },
-
-    'bulk throws errors for string datatypes' (done) {
-      let t = new sql.Table('#bulkconverts')
-      t.create = true
       t.columns.add('a', sql.Int, {
         nullable: false
       })
@@ -552,7 +527,10 @@ module.exports = (sql, driver) => {
       })
 
       table.rows.add(table.rows, ['JP1016'])
-      req.bulk(table, err => {
+      req.bulk(table).then(() => {
+        assert.fail('it should throw error while insertion')
+        done()
+      }).catch(err => {
         assert.strictEqual(err instanceof sql.RequestError, true)
         assert.strictEqual(err.message, 'An unknown error has occurred. This is likely because the schema of the BulkLoad does not match the schema of the table you are attempting to insert into.')
         assert.strictEqual(err.code, 'UNKNOWN')
@@ -570,7 +548,10 @@ module.exports = (sql, driver) => {
       })
 
       table.rows.add(table.rows, ['JP1016'])
-      req.bulk(table, err => {
+      req.bulk(table).then(() => {
+        assert.fail('it should throw error while insertion')
+        done()
+      }).catch(err => {
         assert.strictEqual(err instanceof sql.RequestError, true)
         assert.strictEqual(err.message, 'An unknown error has occurred. This is likely because the schema of the BulkLoad does not match the schema of the table you are attempting to insert into.')
         assert.strictEqual(err.code, 'UNKNOWN')

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -197,6 +197,11 @@ describe('Unit', () => {
     t.columns.add('c', sql.TinyInt, { nullable: false, primary: true })
     assert.strictEqual(t.declare(), 'create table [#mytemptable] ([a] int, [b] tinyint null, [c] tinyint not null, constraint PK_mytemptable primary key (a, c))')
 
+    t = new sql.Table('MyTable')
+    t.columns.add('name', sql.NVarChar, {
+      length: Infinity
+    })
+    assert.strictEqual(t.columns[0].length, Infinity)
     return done()
   })
 

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -123,9 +123,9 @@ describe('tedious', () => {
     it('bulk load with varchar-max field (table)', done => TESTS['bulk load with varchar-max field']('bulk_table2', done))
     it('bulk load (temporary table)', done => TESTS['bulk load']('#anohter_bulk_table', done))
     it('bulk converts dates', done => TESTS['bulk converts dates'](done))
-    it('bulk insert with length option as undefined throws', done => TESTS['bulk insert with length option as undefined throws'](done))
-    it('bulk insert with length option as string throws', done => TESTS['bulk insert with length option as string throws'](done))
-
+    it('bulk insert with length option as undefined throws (table)', done => TESTS['bulk insert with length option as undefined throws']('bulk_table3', done))
+    it('bulk insert with length option as string other than max throws (table)', done => TESTS['bulk insert with length option as string other than max throws']('bulk_table4', done))
+    it('bulk insert with length as max (table)', done => TESTS['bulk insert with length as max']('bulk_table5', done))
     after(done => sql.close(done))
   })
 

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -120,8 +120,11 @@ describe('tedious', () => {
     })
 
     it('bulk load (table)', done => TESTS['bulk load']('bulk_table', done))
+    it('bulk load with varchar-max field (table)', done => TESTS['bulk load with varchar-max field']('bulk_table2', done))
     it('bulk load (temporary table)', done => TESTS['bulk load']('#anohter_bulk_table', done))
     it('bulk converts dates', done => TESTS['bulk converts dates'](done))
+    it('bulk insert with length option as undefined throws', done => TESTS['bulk insert with length option as undefined throws'](done))
+    it('bulk insert with length option as string throws', done => TESTS['bulk insert with length option as string throws'](done))
 
     after(done => sql.close(done))
   })


### PR DESCRIPTION
What this does:
Fixes #891

Adds the ability to set length for an NVARCHAR(MAX) column, which was breaking while bulk insertion.
