### PR TITLE
Fix authentication failing when "@" is present

### DIFF
--- a/lib/connectionstring.js
+++ b/lib/connectionstring.js
@@ -24,7 +24,7 @@ const parseConnectionURI = function (uri) {
 
   if (parsed.username) {
     const auth = [parsed.username, parsed.password]
-    user = auth.shift()
+    user = decodeURIComponent(auth.shift())
     password = decodeURIComponent(auth.join(':'))
   }
 


### PR DESCRIPTION
We're seeing authentication failure when updating to v6 from v5.1.0. I traced it to the fact we use "user@domain" as usernames, and the "@" is being converted to "%40".

This change decodes any items that were encoded and prevents this problem.