### PR TITLE
Additional column info when creating table from recordset

### DIFF
--- a/lib/msnodesqlv8/request.js
+++ b/lib/msnodesqlv8/request.js
@@ -96,7 +96,8 @@ const createColumns = function (metadata) {
       index,
       name: column.name,
       length: column.size,
-      type: DECLARATIONS[column.sqlType]
+      type: DECLARATIONS[column.sqlType],
+      nullable: column.nullable
     }
 
     if (column.udtType != null) {

--- a/lib/table.js
+++ b/lib/table.js
@@ -30,19 +30,17 @@ function Table (name) {
       }
 
       options = options || {}
-      column.name = name
-      column.nullable = options.nullable
-      column.primary = options.primary
-      column.identity = options.identity
-      column.readOnly = options.readOnly
-      if (objectHasProperty(options, 'length')) {
-        column.length = options.length
-      }
+      column.name = name;
+
+      ['nullable', 'primary', 'identity', 'readOnly', 'length'].forEach(prop => {
+        if (objectHasProperty(options, prop)) {
+          column[prop] = options[prop]
+        }
+      })
 
       return this.push(column)
     }
-  }
-  )
+  })
 
   Object.defineProperty(this.rows, 'add', {
     value () {

--- a/lib/table.js
+++ b/lib/table.js
@@ -33,6 +33,8 @@ function Table (name) {
       column.name = name
       column.nullable = options.nullable
       column.primary = options.primary
+      column.identity = options.identity
+      column.readOnly = options.readOnly
       if (objectHasProperty(options, 'length')) {
         column.length = options.length
       }
@@ -126,7 +128,9 @@ Table.fromRecordset = function fromRecordset (recordset, name) {
         scale: col.scale,
         precision: col.precision
       }, {
-        nullable: col.nullable
+        nullable: col.nullable,
+        identity: col.identity,
+        readOnly: col.readOnly
       })
     }
   }

--- a/test/cleanup.sql
+++ b/test/cleanup.sql
@@ -15,6 +15,9 @@ if exists (select * from sys.procedures where name = '__test7')
 
 if exists (select * from sys.types where is_user_defined = 1 and name = 'MSSQLTestType')
 	exec('drop type [dbo].[MSSQLTestType]')
+
+if exists (select * from sys.tables where name = 'prepstm_test')
+	exec('drop table [dbo].[tvp_test]')
 	
 if exists (select * from sys.tables where name = 'prepstm_test')
 	exec('drop table [dbo].[prepstm_test]')

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -1497,6 +1497,18 @@ module.exports = (sql, driver) => {
           done()
         }).catch(done)
       }).catch(done)
+    },
+
+    'Recordset.toTable() from existing' (done) {
+      const req = new TestRequest()
+      req.query('select a, b, c from tvp_test').then(result => {
+        const tvp = result.recordset.toTable('#tvp_test')
+
+        assert.strictEqual(tvp.columns[0].identity, true)
+        assert.strictEqual(tvp.columns[1].nullable, true)
+        assert.strictEqual(tvp.columns[2].readOnly, true)
+        done()
+      }).catch(done)
     }
   }
 }

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -1504,9 +1504,14 @@ module.exports = (sql, driver) => {
       req.query('select a, b, c from tvp_test').then(result => {
         const tvp = result.recordset.toTable('#tvp_test')
 
-        assert.strictEqual(tvp.columns[0].identity, true)
-        assert.strictEqual(tvp.columns[1].nullable, true)
-        assert.strictEqual(tvp.columns[2].readOnly, true)
+        assert.strictEqual(tvp.columns[1].nullable, true, 'the nullable property is not set as true')
+
+        // note: msnodesqlv8 does not provide the identity and readOnly column metadata
+        if (driver !== 'msnodesqlv8') {
+          assert.strictEqual(tvp.columns[0].identity, true, 'the identity property is not set as true')
+          assert.strictEqual(tvp.columns[2].readOnly, true, 'the readOnly property is not set as true')
+        }
+
         done()
       }).catch(done)
     }

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -228,6 +228,7 @@ describe('msnodesqlv8', function () {
 
     it('new Table', done => TESTS['new Table'](done))
     it('Recordset.toTable()', done => TESTS['Recordset.toTable()'](done))
+    it('Recordset.toTable() from existing', done => TESTS['Recordset.toTable() from existing'](done))
 
     after(() => sql.close())
   })

--- a/test/prepare.sql
+++ b/test/prepare.sql
@@ -94,6 +94,12 @@ begin
 
 end')
 
+exec('create table [dbo].[tvp_test] (
+	a int not null identity,
+	b varchar(50) null,
+	c as ''id is '' + cast(a as varchar(10)) persisted
+)')
+
 exec('create table [dbo].[prepstm_test] (
 	data varchar(50) not null
 )')

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -269,6 +269,7 @@ describe('tedious', () => {
 
     it('new Table', done => TESTS['new Table'](done))
     it('Recordset.toTable()', done => TESTS['Recordset.toTable()'](done))
+    it('Recordset.toTable() from existing', done => TESTS['Recordset.toTable() from existing'](done))
 
     class MSSQLTestType extends sql.Table {
       constructor () {


### PR DESCRIPTION
What this does:
Currently the `identity` and `readOnly` properties are lost when converting a recordset to a table. This change passes those properties through to the `Table` instance which is useful when trying to perform bulk operations as writing to these columns will throw errors.