### PR TITLE
Add stored procedure parameters to debug logging

### DIFF
--- a/lib/tedious/request.js
+++ b/lib/tedious/request.js
@@ -757,7 +757,17 @@ class Request extends BaseRequest {
         connection.on('errorMessage', errorHandlers.errorMessage = handleError.bind(null, false, connection))
         connection.on('error', errorHandlers.error = handleError.bind(null, true, connection))
 
-        debug('request(%d): execute', IDS.get(this), procedure)
+        if (debug.enabled) {
+          // log stored procedure executions and provided parameters
+          const params = Object.keys(this.parameters).map(k => this.parameters[k])
+          // cut long string parameters short to keep log somewhat clean
+          const logValue = s => typeof s === 'string' && s.length > 50 ? s.substring(0, 47) + '...' : s
+          // format parameter names as 'my_parameter [sql.Int]'
+          const logName = param => param.name + ' [sql.' + param.type.name + ']'
+          const logParams = {}
+          params.forEach(p => { logParams[logName(p)] = logValue(p.value) })
+          debug('request(%d): execute %s %O', IDS.get(this), procedure, logParams)
+        }
 
         const req = new tds.Request(procedure, err => {
           // to make sure we handle no-sql errors as well


### PR DESCRIPTION
While the `debug` package can be used to see all queries and stored procedure executions, debugging proc-heavy applications is difficult since the log doesn’t contain any parameters.

AFAIK there’s no easy way to add global parameter logging without changing this package, correct me if I'm wrong.

This PR changes the stored procedure debug line to also contain all the provided parameters. Main drawback is additional noise in debug logs, but long strings in parameters are cut short to compensate.