### PR TITLE
FIX Repeat calls to mssql.connect() will only resolve when the pool is connected

### DIFF
--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -234,7 +234,7 @@ class ConnectionPool extends EventEmitter {
         this._connecting = false
         this._connected = true
 
-        callback(null)
+        callback(null, this)
       })
     }).catch(err => {
       this._connecting = false

--- a/lib/global-connection.js
+++ b/lib/global-connection.js
@@ -4,6 +4,7 @@ const shared = require('./shared')
 
 let globalConnection = null
 const globalConnectionHandlers = {}
+let onGlobalConnect = []
 
 /**
  * Open global connection pool.
@@ -14,13 +15,7 @@ const globalConnectionHandlers = {}
  */
 
 function connect (config, callback) {
-  if (globalConnection) {
-    if (typeof callback === 'function') {
-      setImmediate(callback, null, globalConnection)
-    } else {
-      return shared.Promise.resolve(globalConnection)
-    }
-  } else {
+  if (!globalConnection) {
     globalConnection = new shared.driver.ConnectionPool(config)
 
     for (const event in globalConnectionHandlers) {
@@ -53,8 +48,35 @@ function connect (config, callback) {
     }
 
     globalConnection.close = globalClose.bind(globalConnection)
-
-    return globalConnection.connect(callback)
+  }
+  if (!globalConnection.connected && !globalConnection.connecting) {
+    globalConnection.connect((err, pool) => {
+      onGlobalConnect.forEach(cb => {
+        setImmediate(cb, err, pool)
+      })
+      onGlobalConnect = []
+    })
+  }
+  if (globalConnection.connected) {
+    if (typeof callback === 'function') {
+      setImmediate(callback, null, globalConnection)
+      return globalConnection
+    } else {
+      return shared.Promise.resolve(globalConnection)
+    }
+  } else if (typeof callback === 'function') {
+    onGlobalConnect.push(callback)
+    return globalConnection
+  } else {
+    return new shared.Promise((resolve, reject) => {
+      onGlobalConnect.push((err, pool) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(pool)
+        }
+      })
+    })
   }
 }
 

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -898,6 +898,22 @@ module.exports = (sql, driver) => {
       })
     },
 
+    'repeat calls to connect resolve in order' (connect, done) {
+      Promise.all([
+        connect().then((pool) => {
+          assert.ok(pool.connected, 'Pool not connected')
+          return Date.now()
+        }),
+        connect().then((pool) => {
+          assert.ok(pool.connected, 'Pool not connected')
+          return Date.now()
+        })
+      ]).then(([time1, time2]) => {
+        assert.ok(time1 <= time2, 'Connections did not resolve in order')
+        done()
+      }).catch(done)
+    },
+
     'json parser' (done) {
       const req = new TestRequest()
       req.query("select 1 as 'a.b.c', 2 as 'a.b.d', 3 as 'a.x', 4 as 'a.y' for json path;select 5 as 'a.b.c', 6 as 'a.b.d', 7 as 'a.x', 8 as 'a.y' for json path;with n(n) as (select 1 union all select n  +1 from n where n < 1000) select n from n order by n option (maxrecursion 1000) for json auto;").then(result => {

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -1,6 +1,6 @@
 'use strict'
 
-/* globals describe, it, before, after */
+/* globals describe, it, before, after, afterEach */
 
 const sql = require('../../msnodesqlv8')
 
@@ -90,6 +90,11 @@ describe('msnodesqlv8', function () {
     it('chunked xml support', done => TESTS['chunked xml support'](done))
 
     after(() => sql.close())
+  })
+
+  describe('global connection', () => {
+    it('repeat calls to connect resolve in order', done => TESTS['repeat calls to connect resolve in order'](sql.connect.bind(sql, config()), done))
+    afterEach(done => sql.close(done))
   })
 
   describe('json support (requires SQL Server 2016)', () => {

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -1,6 +1,6 @@
 'use strict'
 
-/* globals describe, it, before, after */
+/* globals describe, it, before, after, afterEach */
 
 const sql = require('../../tedious.js')
 const assert = require('assert')
@@ -91,6 +91,11 @@ describe('tedious', () => {
     it('chunked xml support', done => TESTS['chunked xml support'](done))
 
     after(done => sql.close(done))
+  })
+
+  describe('global connection', () => {
+    it('repeat calls to connect resolve in order', done => TESTS['repeat calls to connect resolve in order'](sql.connect.bind(sql, config()), done))
+    afterEach(done => sql.close(done))
   })
 
   describe('json support (requires SQL Server 2016)', () => {


### PR DESCRIPTION
This is an improvement on https://github.com/tediousjs/node-mssql/pull/804

Since the previous PR repeated calls to `mssql.connect()` would resolve instantly even if the pool wasn't yet in a connected state. eg:

```js
const pool = mssql.connect().then(() => console.log('first'));
const pool2 = mssql.connect().then(() => console.log('second'));

// output:
// second
// first
```

This has lead to many issues where developers are not taking into account that they shouldn't be relying on being able to call `connect()` repeatedly.

This will improve developer experience as they will need to think less about managing the state of their global connection

todo: 
 - [x] tests