### PR TITLE
Default Isolation Level for all Transactions

### DIFF
--- a/lib/base/transaction.js
+++ b/lib/base/transaction.js
@@ -33,7 +33,7 @@ class Transaction extends EventEmitter {
     debug('transaction(%d): created', IDS.get(this))
 
     this.parent = parent || globalConnection.pool
-    this.isolationLevel = ISOLATION_LEVEL.READ_COMMITTED
+    this.isolationLevel = Transaction.defaultIsolationLevel
     this.name = ''
   }
 
@@ -250,5 +250,12 @@ class Transaction extends EventEmitter {
     setImmediate(callback)
   }
 }
+
+/**
+ * Default isolation level used for any transactions that don't explicitly specify an isolation level.
+ *
+ * @type {number}
+ */
+Transaction.defaultIsolationLevel = ISOLATION_LEVEL.READ_COMMITTED
 
 module.exports = Transaction

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -3,6 +3,7 @@
 const assert = require('assert')
 const stream = require('stream')
 const ISOLATION_LEVELS = require('../../lib/isolationlevel')
+const BaseTransaction = require('../../lib/base/transaction')
 
 process.on('unhandledRejection', (reason, p) => {
   console.log('Unhandled Rejection at: Promise', p, 'reason:', reason)
@@ -781,14 +782,15 @@ module.exports = (sql, driver) => {
     },
 
     'transaction uses default isolation level' (done) {
-      const originalIsolationLevel = TestTransaction.defaultIsolationLevel
+      const originalIsolationLevel = BaseTransaction.defaultIsolationLevel
       assert.strictEqual(originalIsolationLevel, ISOLATION_LEVELS.READ_COMMITTED)
-      TestTransaction.defaultIsolationLevel = ISOLATION_LEVELS.READ_UNCOMMITTED
+      BaseTransaction.defaultIsolationLevel = ISOLATION_LEVELS.READ_UNCOMMITTED
       const tran = new TestTransaction()
       assert.strictEqual(tran.isolationLevel, ISOLATION_LEVELS.READ_UNCOMMITTED)
 
       // Reset to originalIsolationLevel
-      TestTransaction.defaultIsolationLevel = originalIsolationLevel
+      BaseTransaction.defaultIsolationLevel = originalIsolationLevel
+      done()
     },
 
     'transaction with error' (done) {

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -780,6 +780,17 @@ module.exports = (sql, driver) => {
       })
     },
 
+    'transaction uses default isolation level' (done) {
+      const originalIsolationLevel = TestTransaction.defaultIsolationLevel
+      assert.strictEqual(originalIsolationLevel, ISOLATION_LEVELS.READ_COMMITTED)
+      TestTransaction.defaultIsolationLevel = ISOLATION_LEVELS.READ_UNCOMMITTED
+      const tran = new TestTransaction()
+      assert.strictEqual(tran.isolationLevel, ISOLATION_LEVELS.READ_UNCOMMITTED)
+
+      // Reset to originalIsolationLevel
+      TestTransaction.defaultIsolationLevel = originalIsolationLevel
+    },
+
     'transaction with error' (done) {
       const tran = new TestTransaction()
       tran.begin().then(() => {

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -82,6 +82,7 @@ describe('msnodesqlv8', function () {
     it('transaction with commit', done => TESTS['transaction with commit'](done))
     it('transaction throws on bad isolation level', done => TESTS['transaction throws on bad isolation level'](done))
     it('transaction accepts good isolation levels', done => TESTS['transaction accepts good isolation levels'](done))
+    it('transaction uses default isolation level', done => TESTS['transaction uses default isolation level'](done))
     it('cancel request', done => TESTS['cancel request'](done))
     it('allows repeat calls to connect', done => TESTS['repeat calls to connect resolve'](config(), done))
     it('calls to close during connection throw', done => TESTS['calls to close during connection throw'](config(), done))

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -79,6 +79,7 @@ describe('tedious', () => {
     it('transaction with commit', done => TESTS['transaction with commit'](done))
     it('transaction throws on bad isolation level', done => TESTS['transaction throws on bad isolation level'](done))
     it('transaction accepts good isolation levels', done => TESTS['transaction accepts good isolation levels'](done))
+    it('transaction uses default isolation level', done => TESTS['transaction uses default isolation level'](done))
     it('transaction with error (XACT_ABORT set to ON)', done => TESTS['transaction with error'](done))
     it('transaction with synchronous error', done => TESTS['transaction with synchronous error'](done))
     it('cancel request', done => TESTS['cancel request'](done, /Canceled./))


### PR DESCRIPTION
What this does:

- Adds static attribute `defaultIsolationLevel` to `Transaction` (which defaults to the current value  `ISOLATION_LEVEL.READ_COMMITTED`)
- If a user wants to change the isolation level globally for an app, they have to update `Transaction.defaultIsolationLevel` to the desired isolation level.

Example:

```javascript
Transaction.defaultIsolationLevel = ISOLATION_LEVEL.READ_UNCOMMITTED

// All transactions will now have the isolation level READ_UNCOMMITTED unless explicitly specified on each transaction
```