### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Supported TDS drivers:
 ## Quick Example
 
 ```javascript
-const sql = require('mssql')
+const sql = require('mssql');
 
-async () => {
+(async () => {
     try {
         // make sure that any items are correctly URL encoded in the connection string
         await sql.connect('mssql://username:password@localhost/database')
@@ -26,7 +26,7 @@ async () => {
     } catch (err) {
         // ... error checks
     }
-}
+})();
 ```
 
 If you're on Windows Azure, add `?encrypt=true` to your connection string. See [docs](#configuration) to learn more.


### PR DESCRIPTION
Add IIFE in the quick example

What this does: The quick example was not working because the async was never called. I fix this by adding IIFE functionality. 
