### PR TITLE
FIX Dont use .inspect for util.inspect anymore

### DIFF
--- a/lib/datatypes.js
+++ b/lib/datatypes.js
@@ -1,4 +1,5 @@
 'use strict'
+const inspect = Symbol.for('nodejs.util.inspect.custom')
 
 const TYPES = {
   VarChar (length) {
@@ -124,7 +125,7 @@ for (const key in TYPES) {
     module.exports.DECLARATIONS[value.declaration] = value;
 
     ((key, value) => {
-      value.inspect = () => `[sql.${key}]`
+      value[inspect] = () => `[sql.${key}]`
     })(key, value)
   }
 }


### PR DESCRIPTION
What this does:

fixes #1062 

see https://nodejs.org/api/deprecations.html#deprecations_dep0079_custom_inspection_function_on_objects_via_inspect