### PR TITLE
Enable pipe to support back pressure and errors

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,9 @@
 v7.0.0 (2020-??-??)
 -------------------
 [change] Updated to latest Tedious 9
-[change] Piped streams no longer have errors forwarded on to them ([1028](https://github.com/tediousjs/node-mssql/pull/1028))
-[change] tedious config option `trustServerCertificate` defaults to `false` if not supplied ([1030](https://github.com/tediousjs/node-mssql/pull/1030))
+[change] Piped streams no longer have errors forwarded on to them ([#1028](https://github.com/tediousjs/node-mssql/pull/1028))
+[change] tedious config option `trustServerCertificate` defaults to `false` if not supplied ([#1030](https://github.com/tediousjs/node-mssql/pull/1030))
+[change] Request.pipe now pipes a true node stream for better support of backpressure ([#1078](https://github.com/tediousjs/node-mssql/pull/1078))
 [change] drop support for NodeJS < 10 ([#1070](https://github.com/tediousjs/node-mssql/pull/1070))
 [fix] Avoid using deprecated `.inspect` on Objects ([#1071](https://github.com/tediousjs/node-mssql/pull/1071))
 [fix] Bump various dependencies for security fixes ([#1102](https://github.com/tediousjs/node-mssql/pull/1102))

--- a/README.md
+++ b/README.md
@@ -884,6 +884,16 @@ pipeline(readableStream, transformStream, writableStream)
 request.query('select * from mytable')
 ```
 
+OR if you wanted to increase the highWaterMark of the read stream to buffer more rows in memory
+
+```javascript
+const { pipeline } = require('stream')
+const request = new sql.Request()
+const readableStream = request.toReadableStream({ highWaterMark: 100 })
+pipeline(readableStream, transformStream, writableStream)
+request.query('select * from mytable')
+```
+
 
 ### pipe (stream)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Parts of the connection URI should be correctly URL encoded so that the URI can 
 * [execute](#execute-procedure-callback)
 * [input](#input-name-type-value)
 * [output](#output-name-type-value)
+* [toReadableStream](#to-readable-stream)
 * [pipe](#pipe-stream)
 * [query](#query-command-callback)
 * [batch](#batch-batch-callback)
@@ -868,6 +869,25 @@ __Errors__ (synchronous)
 - EINJECT (`RequestError`) - SQL injection warning.
 
 ---------------------------------------
+
+### toReadableStream
+
+Convert request to a Node.js ReadableStream
+
+__Arguments__
+
+- **stream** - Writable stream in object mode.
+
+__Example__
+
+```javascript
+const { pipeline } = require('stream')
+const request = new sql.Request()
+const readableStream = request.toReadableStream()
+pipeline(readableStream, transformStream, writableStream)
+request.query('select * from mytable')
+```
+
 
 ### pipe (stream)
 

--- a/README.md
+++ b/README.md
@@ -874,10 +874,6 @@ __Errors__ (synchronous)
 
 Convert request to a Node.js ReadableStream
 
-__Arguments__
-
-- **stream** - Writable stream in object mode.
-
 __Example__
 
 ```javascript

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
   # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - npm install
-  - npm install msnodesqlv8
+  - npm install msnodesqlv8@^1
 
 platform:
   - x86

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -369,12 +369,14 @@ class Request extends EventEmitter {
    * Wrap original request in a Readable stream that supports back pressure and return.
    * It also sets request to `stream` mode and pulls all rows from all recordsets to a given stream.
    *
+   * @param {Object} streamOptions - optional options to configure the readable stream with like highWaterMark
    * @return {Stream}
    */
-  toReadableStream () {
+  toReadableStream (streamOptions = {}) {
     this.stream = true
     this.pause()
     const readableStream = new Readable({
+      ...streamOptions,
       objectMode: true,
       read: (/* size */) => {
         this.resume()

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -366,18 +366,17 @@ class Request extends EventEmitter {
   }
 
   /**
-   * Wrap original request in a Readable stream that supports back pressure and pipe to the Writable stream.
+   * Wrap original request in a Readable stream that supports back pressure and return.
    * It also sets request to `stream` mode and pulls all rows from all recordsets to a given stream.
    *
-   * @param {Stream} writableStream Stream to pipe data into.
    * @return {Stream}
    */
-  pipe (writableStream) {
+  toReadableStream () {
     this.stream = true
     this.pause()
     const readableStream = new Readable({
       objectMode: true,
-      read:  (/* size */) => {
+      read: (/* size */) => {
         this.resume()
       }
     })
@@ -392,6 +391,18 @@ class Request extends EventEmitter {
     this.on('done', () => {
       readableStream.push(null)
     })
+    return readableStream
+  }
+
+  /**
+   * Wrap original request in a Readable stream that supports back pressure and pipe to the Writable stream.
+   * It also sets request to `stream` mode and pulls all rows from all recordsets to a given stream.
+   *
+   * @param {Stream} stream Stream to pipe data into.
+   * @return {Stream}
+   */
+  pipe (writableStream) {
+    const readableStream = this.toReadableStream()
     return readableStream.pipe(writableStream)
   }
 

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -2,6 +2,7 @@
 
 const debug = require('debug')('mssql:base')
 const { EventEmitter } = require('events')
+const { Readable } = require('stream')
 const { IDS, objectHasProperty } = require('../utils')
 const globalConnection = require('../global-connection')
 const { RequestError, ConnectionError } = require('../error')
@@ -365,20 +366,33 @@ class Request extends EventEmitter {
   }
 
   /**
-   * Sets request to `stream` mode and pulls all rows from all recordsets to a given stream.
+   * Wrap original request in a Readable stream that supports back pressure and pipe to the Writable stream.
+   * It also sets request to `stream` mode and pulls all rows from all recordsets to a given stream.
    *
-   * @param {Stream} stream Stream to pipe data into.
+   * @param {Stream} writableStream Stream to pipe data into.
    * @return {Stream}
    */
-
-  pipe (stream) {
+  pipe (writableStream) {
     this.stream = true
-    this.on('row', stream.write.bind(stream))
-    this.on('done', () => {
-      setImmediate(() => stream.end())
+    this.pause()
+    const readableStream = new Readable({
+      objectMode: true,
+      read:  (/* size */) => {
+        this.resume()
+      }
     })
-    stream.emit('pipe', this)
-    return stream
+    this.on('row', (row) => {
+      if (!readableStream.push(row)) {
+        this.pause()
+      }
+    })
+    this.on('error', (error) => {
+      readableStream.emit('error', error)
+    })
+    this.on('done', () => {
+      readableStream.push(null)
+    })
+    return readableStream.pipe(writableStream)
   }
 
   /**

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -457,7 +457,7 @@ module.exports = (sql, driver) => {
       req.on('row', () => {
         readRowCount += 1
       })
-      req.query(`select * from streaming order by text offset 0 rows fetch first ${rowCountLimit} rows only`)
+      req.query(`select top ${rowCountLimit} * from streaming order by text`)
       req.pipe(blockingTransformStream).pipe(wstream)
     },
 

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -397,6 +397,23 @@ module.exports = (sql, driver) => {
       })
     },
 
+    'query with toReadableStream' (done) {
+      const stream = new WritableStream()
+      stream.on('finish', () => {
+        assert.strictEqual(stream.cache.length, 1)
+        assert.strictEqual(stream.cache[0].text, 'asdf')
+        done()
+      })
+      stream.on('error', err => {
+        done(err)
+      })
+
+      const req = new sql.Request()
+      const readableStream = req.toReadableStream()
+      readableStream.pipe(stream)
+      req.query('select \'asdf\' as text')
+    },
+
     'query with pipe' (done) {
       const stream = new WritableStream()
       stream.on('finish', () => {

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -62,7 +62,7 @@ describe('msnodesqlv8', function () {
     it.skip('query with raiseerror (not supported by msnodesqlv8)', done => TESTS['query with raiseerror'](done))
     it('query with toReadableStream', done => TESTS['query with toReadableStream'](done))
     it('query with pipe', done => TESTS['query with pipe'](done))
-    it('query with pipe and back pressure', (done) => TESTS['query with pipe and back pressure'](done))
+    it.skip('query with pipe and back pressure', (done) => TESTS['query with pipe and back pressure'](done))
     it('batch', done => TESTS.batch(done))
     it('batch (stream)', done => TESTS.batch(done, true))
     it('create procedure batch', done => TESTS['create procedure batch'](done))

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -61,6 +61,7 @@ describe('msnodesqlv8', function () {
     it.skip('query with multiple errors (not supported by msnodesqlv8)', done => TESTS['query with multiple errors'](done))
     it.skip('query with raiseerror (not supported by msnodesqlv8)', done => TESTS['query with raiseerror'](done))
     it('query with pipe', done => TESTS['query with pipe'](done))
+    it('query with pipe and back pressure', (done) => TESTS['query with pipe and back pressure'](done))
     it('batch', done => TESTS.batch(done))
     it('batch (stream)', done => TESTS.batch(done, true))
     it('create procedure batch', done => TESTS['create procedure batch'](done))

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -60,6 +60,7 @@ describe('msnodesqlv8', function () {
     it('query with error', done => TESTS['query with error'](done))
     it.skip('query with multiple errors (not supported by msnodesqlv8)', done => TESTS['query with multiple errors'](done))
     it.skip('query with raiseerror (not supported by msnodesqlv8)', done => TESTS['query with raiseerror'](done))
+    it('query with toReadableStream', done => TESTS['query with toReadableStream'](done))
     it('query with pipe', done => TESTS['query with pipe'](done))
     it('query with pipe and back pressure', (done) => TESTS['query with pipe and back pressure'](done))
     it('batch', done => TESTS.batch(done))

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -68,6 +68,7 @@ describe('tedious', () => {
     it('query with multiple errors', done => TESTS['query with multiple errors'](done))
     it('query with raiseerror', done => TESTS['query with raiseerror'](done))
     it('query with pipe', done => TESTS['query with pipe'](done))
+    it('query with pipe and back pressure', (done) => TESTS['query with pipe and back pressure'](done))
     it('batch', done => TESTS.batch(done))
     it('create procedure batch', done => TESTS['create procedure batch'](done))
     it('prepared statement', done => TESTS['prepared statement'](done))

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -67,6 +67,7 @@ describe('tedious', () => {
     it('query with error', done => TESTS['query with error'](done))
     it('query with multiple errors', done => TESTS['query with multiple errors'](done))
     it('query with raiseerror', done => TESTS['query with raiseerror'](done))
+    it('query with toReadableStream', done => TESTS['query with toReadableStream'](done))
     it('query with pipe', done => TESTS['query with pipe'](done))
     it('query with pipe and back pressure', (done) => TESTS['query with pipe and back pressure'](done))
     it('batch', done => TESTS.batch(done))


### PR DESCRIPTION
`pipe` method should support Node.js stream back pressure and forward errors to the stream.

What this does:

Modify `pipe` method to wrap the original request in a Readable stream and pipe it to the incoming stream. Errors are forwarded to the stream as well.
