### PR TITLE
Add table.rows.clear() method for chunking table row updates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 v8.0.0 (2021-??-??)
 -------------------
+[new] Add table.rows.clear() method to allow for chunking updates ([#1094](https://github.com/tediousjs/node-mssql/pull/1094))
 [change] msnodesqlv8 driver detects os platform and attempts to pick correct connections string for it ((#1318)[https://github.com/tediousjs/node-mssql/pull/1318])
 [change] Updated to latest Tedious 14 ((#1312)[https://github.com/tediousjs/node-mssql/pull/1312])
 [change] Errors for bad bulk load parameters have slightly different error messages ((#1318)[https://github.com/tediousjs/node-mssql/pull/1318])
@@ -255,7 +256,7 @@ v4.0.4 (2017-04-25)
 
 v4.0.3 (2017-04-25)
 -------------------
-[fix] Fixed broken CLI & debugging
+[fix] Fixed broken CLI & debugging
 
 v4.0.2 (2017-04-19)
 -------------------
@@ -276,7 +277,7 @@ v4.0.0 (2017-04-01)
 [change] Removed verbose and debug mode
 [change] Removed 'driver' from options
 [change] Removed Transaction and Prepared Statement queues
-[change] Removed 'multiple' directive
+[change] Removed 'multiple' directive
 [change] Connection renamed to ConnectionPool
 [change] Updated to latest Tedious 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -1616,6 +1616,20 @@ request.execute('MyCustomStoredProcedure', (err, result) => {
 
 **TIP**: You can also create Table variable from any recordset with `recordset.toTable()`. You can optionally specify table type name in the first argument.
 
+You can clear the table rows for easier batching by using `table.rows.clear()`
+
+```js
+const tvp = new sql.Table() // You can optionally specify table type name in the first argument.
+
+// Columns must correspond with type we have created in database.
+tvp.columns.add('a', sql.VarChar(50))
+tvp.columns.add('b', sql.Int)
+
+// Add rows
+tvp.rows.add('hello tvp', 777) // Values are in same order as columns.
+tvp.rows.clear()
+```
+
 ## Response Schema
 
 An object returned from a `sucessful` basic query would look like the following.

--- a/lib/table.js
+++ b/lib/table.js
@@ -48,6 +48,13 @@ function Table (name) {
     }
   }
   )
+
+  Object.defineProperty(this.rows, 'clear', {
+    value () {
+      return this.splice(0, this.length)
+    }
+  }
+  )
 }
 
 /*

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -140,6 +140,9 @@ describe('Unit', () => {
     assert.deepStrictEqual(t.rows[3], [12, 'XCXCDCDSCDSC'])
     assert.strictEqual(t.temporary, false)
 
+    t.rows.clear()
+    assert.strictEqual(t.rows.length, 0)
+
     t = new sql.Table('schm.MyTable')
 
     assert.strictEqual(t.name, 'MyTable')


### PR DESCRIPTION
https://github.com/tediousjs/node-mssql/issues/1087

What this does: adds new method table.rows.clear()
