### PR TITLE
Drop node10 conditional test runs

### DIFF
--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -16,15 +16,6 @@ const config = function () {
 let connection1 = null
 let connection2 = null
 
-function itNode10 () {
-  const [major] = process.version.split('.')
-  if (major.substr(1) >= 10) {
-    it(...arguments)
-  } else {
-    it.skip(...arguments)
-  }
-}
-
 describe('msnodesqlv8', function () {
   before(done =>
     sql.connect(config(), function (err) {
@@ -213,10 +204,10 @@ describe('msnodesqlv8', function () {
     it.skip('concurrent requests', done => TESTS['concurrent requests'](done))
     it('streaming off', done => TESTS['streaming off'](done))
     it('streaming on', done => TESTS['streaming on'](done))
-    itNode10('streaming pause', done => TESTS['streaming pause'](done))
-    itNode10('streaming resume', done => TESTS['streaming resume'](done))
-    itNode10('a cancelled stream emits done event', done => TESTS['a cancelled stream emits done event'](done))
-    itNode10('a cancelled paused stream emits done event', done => TESTS['a cancelled paused stream emits done event'](done))
+    it('streaming pause', done => TESTS['streaming pause'](done))
+    it('streaming resume', done => TESTS['streaming resume'](done))
+    it('a cancelled stream emits done event', done => TESTS['a cancelled stream emits done event'](done))
+    it('a cancelled paused stream emits done event', done => TESTS['a cancelled paused stream emits done event'](done))
 
     after(done => sql.close(done))
   })


### PR DESCRIPTION
What this does:

- Removes legacy testsuite code that conditionally runs tests based on if we are >= node 10

This is no longer required as we only support node 10+