### PR TITLE
FIX Remove reference to global pool on connection error

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+v6.2.3 (2020-09-xx)
+-------------------
+[fix] Remove reference to global pool on connection error ([#1107](https://github.com/tediousjs/node-mssql/pull/1107))
+
 v6.2.2 (2020-09-18)
 -------------------
 [fix] Avoid using deprecated `.inspect` on Objects ([#1071](https://github.com/tediousjs/node-mssql/pull/1071))

--- a/lib/global-connection.js
+++ b/lib/global-connection.js
@@ -48,7 +48,18 @@ function connect (config, callback) {
 
     globalConnection.close = globalClose.bind(globalConnection)
   }
-  return globalConnection.connect(callback)
+  if (typeof callback === 'function') {
+    return globalConnection.connect((err, connection) => {
+      if (err) {
+        globalConnection = null
+      }
+      callback(err, connection)
+    })
+  }
+  return globalConnection.connect().catch((err) => {
+    globalConnection = null
+    return shared.Promise.reject(err)
+  })
 }
 
 /**


### PR DESCRIPTION
What this does:

This fixes an issue where the reference to the global connection is not removed if the initial connection attempt fails