### PR TITLE
Fix streaming trailing rows with msnodesqlv8 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Microsoft SQL Server client for Node.js
 
 Supported TDS drivers:
 - [Tedious][tedious-url] (pure JavaScript - Windows/macOS/Linux, default)
-- [Microsoft / Contributors Node V8 Driver for Node.js for SQL Server][msnodesqlv8-url] (native - Windows only)
+- [Microsoft / Contributors Node V8 Driver for Node.js for SQL Server][msnodesqlv8-url] (native - Windows/Linux only)
 
 ## Installation
 
@@ -660,7 +660,7 @@ More information about Tedious specific options: http://tediousjs.github.io/tedi
 
 ### Microsoft / Contributors Node V8 Driver for Node.js for SQL Server
 
-**Requires Node.js 0.12.x or newer. Windows only.** This driver is not part of the default package and must be installed separately by `npm install msnodesqlv8`. To use this driver, use this require syntax: `const sql = require('mssql/msnodesqlv8')`.
+**Requires Node.js 0.12.x or newer. Windows/Linux only.** This driver is not part of the default package and must be installed separately by `npm install msnodesqlv8`. To use this driver, use this require syntax: `const sql = require('mssql/msnodesqlv8')`.
 
 **Extra options:**
 

--- a/lib/msnodesqlv8/request.js
+++ b/lib/msnodesqlv8/request.js
@@ -396,12 +396,12 @@ class Request extends BaseRequest {
               }
 
               chunksBuffer = null
+              if (row && row.___return___ == null) {
+                // row with ___return___ col is the last row
+                if (this.stream && !this.paused) this.emit('row', row)
+              }
             }
 
-            if (row && row.___return___ == null) {
-              // row with ___return___ col is the last row
-              if (this.stream && !this.paused) this.emit('row', row)
-            }
           }
 
           row = null
@@ -436,14 +436,7 @@ class Request extends BaseRequest {
         })
 
         req.on('row', rownumber => {
-          if (row) {
-            if (isChunkedRecordset) return
-
-            if (row.___return___ == null) {
-              // row with ___return___ col is the last row
-              if (this.stream && !this.paused) this.emit('row', row)
-            }
-          }
+          if (row && isChunkedRecordset) return
 
           row = {}
 
@@ -465,6 +458,11 @@ class Request extends BaseRequest {
               }
             } else {
               row[columns[idx].name] = data
+            }
+            if (row.___return___ == null) {
+              if (this.stream && !this.paused && idx == columns.length - 1) {
+                this.emit('row', row)
+              }
             }
           }
         })
@@ -525,12 +523,12 @@ class Request extends BaseRequest {
                 }
 
                 chunksBuffer = null
+                if (row && row.___return___ == null) {
+                  // row with ___return___ col is the last row
+                  if (this.stream && !this.paused) { this.emit('row', row) }
+                }
               }
 
-              if (row && row.___return___ == null) {
-                // row with ___return___ col is the last row
-                if (this.stream && !this.paused) { this.emit('row', row) }
-              }
             }
 
             // do we have output parameters to handle?

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -206,6 +206,7 @@ describe('msnodesqlv8', function () {
     it('streaming on', done => TESTS['streaming on'](done))
     it('streaming pause', done => TESTS['streaming pause'](done))
     it('streaming resume', done => TESTS['streaming resume'](done))
+    it('streaming trailing rows', done => TESTS[ 'streaming trailing rows'](done))
     it('a cancelled stream emits done event', done => TESTS['a cancelled stream emits done event'](done))
     it('a cancelled paused stream emits done event', done => TESTS['a cancelled paused stream emits done event'](done))
 

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -256,6 +256,7 @@ describe('tedious', () => {
     it('streaming on', done => TESTS['streaming on'](done))
     it('streaming pause', done => TESTS['streaming pause'](done))
     it('streaming resume', done => TESTS['streaming resume'](done))
+    it('streaming trailing rows', done => TESTS[ 'streaming trailing rows'](done))
     it('a cancelled stream emits done event', done => TESTS['a cancelled stream emits done event'](done))
     it('a cancelled paused stream emits done event', done => TESTS['a cancelled paused stream emits done event'](done))
 


### PR DESCRIPTION
What this does: Streams all row results when querying with msnodesqlv8.

Currently, trailing rows are not properly returned in all cases (i.e. when pausing/resuming every 10 rows, with 102 rows, the last row is never returned).

`msnodesqlv8` fires a `row` event before emitting the `column` events with the column data, Currently, `mssql` returns the _previous_ row each time it handles a `row` event (so that the row will have been populated by the `column` events). Usually, the final row was handled in the `done` event handler. However, in the above scenario, the last `column` event gets handled after the `done` event handler. 

This change switches from emitting rows on the `msnodesqlv8` `row` events to emitting them after the final `column` event for that row is processed. This is similar to how `msnodesqlv8` implements [sequilize support](https://github.com/TimelordUK/node-sqlserver-v8/blob/33b0fcd76af71599c7335d4569e362a2e0b73c42/lib/sequelize/request.js#L64).