### PR TITLE
Example of invalid parameter type for stored procedure exhausting the connection pool [Do Not Merge]

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,16 +133,16 @@ const sql = require('mssql')
         let result1 = await pool.request()
             .input('input_parameter', sql.Int, value)
             .query('select * from mytable where id = @input_parameter')
-            
+
         console.dir(result1)
-    
+
         // Stored procedure
-        
+
         let result2 = await pool.request()
             .input('input_parameter', sql.Int, value)
             .output('output_parameter', sql.VarChar(50))
             .execute('procedure_name')
-        
+
         console.dir(result2)
     } catch (err) {
         // ... error checks
@@ -167,7 +167,7 @@ sql.on('error', err => {
 
 sql.connect(config).then(pool => {
     // Query
-    
+
     return pool.request()
         .input('input_parameter', sql.Int, value)
         .query('select * from mytable where id = @input_parameter')
@@ -188,9 +188,9 @@ sql.on('error', err => {
 })
 
 sql.connect(config).then(pool => {
-    
+
     // Stored procedure
-    
+
     return pool.request()
         .input('input_parameter', sql.Int, value)
         .output('output_parameter', sql.VarChar(50))
@@ -222,7 +222,7 @@ sql.on('error', err => {
 })
 ```
 
-All values are automatically sanitized against sql injection. 
+All values are automatically sanitized against sql injection.
 This is because it is rendered as prepared statement, and thus all limitations imposed in MS SQL on parameters apply.
 e.g. Column names cannot be passed/set in statements using variables.
 
@@ -430,7 +430,7 @@ your application is shutting down.
 
 Using a single connection pool for your application/service is recommended.
 Instantiating a pool with a callback, or immediately calling `.connect`, is asynchronous to ensure a connection can be
-established before returning. From that point, you're able to acquire connections as normal:  
+established before returning. From that point, you're able to acquire connections as normal:
 
 ```javascript
 const sql = require('mssql')
@@ -1316,7 +1316,7 @@ ps.prepare('select @param as value', err => {
 
         console.log(result.recordset[0].value) // return 12345
         console.log(result.rowsAffected) // Returns number of affected rows in case of INSERT, UPDATE or DELETE statement.
-        
+
         ps.unprepare(err => {
             // ... error checks
         })
@@ -1349,9 +1349,9 @@ ps.prepare('select @param as value', err => {
 
     request.on('done', result => {
         // Always emitted as the last one
-        
+
         console.log(result.rowsAffected) // Returns number of affected rows in case of INSERT, UPDATE or DELETE statement.
-        
+
         ps.unprepare(err => {
             // ... error checks
         })
@@ -1408,7 +1408,8 @@ Create a `.mssql.json` configuration file (anywhere). Structure of the file is t
     "user": "...",
     "password": "...",
     "server": "localhost",
-    "database": "..."
+    "database": "...",
+    "options": {}
 }
 ```
 

--- a/lib/tedious/request.js
+++ b/lib/tedious/request.js
@@ -929,7 +929,14 @@ class Request extends BaseRequest {
           }
         }
 
-        connection.callProcedure(req)
+        try {
+          // this may throw if a parameter type conversion fails in tedious < 9
+          connection.callProcedure(req)
+        } catch (err) {
+          connection.close() // connection is in an invalid state that can't be recovered, so close it
+          this.parent.release(connection)
+          return callback(err)
+        }
       })
     })
   }

--- a/test/cleanup.sql
+++ b/test/cleanup.sql
@@ -10,6 +10,9 @@ if exists (select * from sys.procedures where name = '__test3')
 if exists (select * from sys.procedures where name = '__test5')
 	exec('drop procedure [dbo].[__test5]')
 
+if exists (select * from sys.procedures where name = '__test6')
+	exec('drop procedure [dbo].[__test6]')
+
 if exists (select * from sys.procedures where name = '__test7')
 	exec('drop procedure [dbo].[__test7]')
 
@@ -18,13 +21,13 @@ if exists (select * from sys.types where is_user_defined = 1 and name = 'MSSQLTe
 
 if exists (select * from sys.tables where name = 'prepstm_test')
 	exec('drop table [dbo].[tvp_test]')
-	
+
 if exists (select * from sys.tables where name = 'prepstm_test')
 	exec('drop table [dbo].[prepstm_test]')
-	
+
 if exists (select * from sys.tables where name = 'tran_test')
 	exec('drop table [dbo].[tran_test]')
-	
+
 if exists (select * from sys.tables where name = 'bulk_table')
 	exec('drop table [dbo].[bulk_table]')
 

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -242,6 +242,32 @@ module.exports = (sql, driver) => {
       }).catch(done)
     },
 
+    async 'stored procedure calling with invalid type' (done) {
+      try {
+        // previously this would exhaust the connection pool
+        for (let i = 0; i < 100; i++) {
+          let didThrow = false
+          try {
+            let req = new TestRequest()
+            req = req.input('id', sql.UniqueIdentifier, 'invalid-guid')
+            await req.execute('__test6')
+          } catch {
+            didThrow = true
+          }
+          assert.strictEqual(didThrow, true)
+        }
+
+        // ensure a new valid request works
+        let req = new TestRequest()
+        req = req.input('id', sql.UniqueIdentifier, 'ff775ea1-e1d5-42ff-92fa-fd3df0a232dd')
+        const result = await req.execute('__test6')
+        assert.strictEqual(result.returnValue, 1)
+        done()
+      } catch (err) {
+        done(err)
+      }
+    },
+
     'empty query' (done) {
       const req = new TestRequest()
       req.query('').then(result => {
@@ -1538,7 +1564,7 @@ module.exports = (sql, driver) => {
 
         done()
       }).catch(done)
-    }
+    },
   }
 }
 

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -56,6 +56,7 @@ describe('msnodesqlv8', function () {
     it('binary data', done => TESTS['binary data'](done))
     it('variant data', done => TESTS['variant data'](done))
     it('stored procedure with one empty recordset', done => TESTS['stored procedure with one empty recordset'](done))
+    it('stored procedure calling with invalid type', done => { TESTS['stored procedure calling with invalid type'](done) })
     it('empty query', done => TESTS['empty query'](done))
     it('query with no recordset', done => TESTS['query with no recordset'](done))
     it('query with one recordset', done => TESTS['query with one recordset'](done))

--- a/test/prepare.sql
+++ b/test/prepare.sql
@@ -11,33 +11,33 @@ exec('create procedure [dbo].[__test]
 	@out5 char(10) = null output
 as
 begin
-		
+
 	set nocount on;
-	
+
 	declare @table table (a int, b int)
 	insert into @table values (1, 2)
 	insert into @table values (3, 4)
-	
+
 	select * from @table
-	
+
 	select 5 as ''c'', 6 as ''d'', @in2 as ''e'', 111 as ''e'', ''asdf'' as ''e'', null as ''f'', @in3 as ''g''
-	
+
 	select * from @table where a = 11
-	
+
 	set @out = 99
 	set @out2 = @in
 	set @out3 = @in4
 	set @out4 = @in5
 	set @out5 = @in3
-	
+
 	return 11
-	
+
 end')
 
 exec('create procedure [dbo].[__test2]
 as
 begin
-	
+
 	set nocount on
 
 	declare @table table (a int, b int)
@@ -52,7 +52,7 @@ end')
 exec('create procedure [dbo].[__test3]
 as
 begin
-	
+
 	with n(n) as (select 1 union all select n  +1 from n where n < 1000) select n from n order by n option (maxrecursion 1000) for xml auto;
 
 end')
@@ -68,7 +68,7 @@ exec('create procedure [dbo].[__test5]
 	@out2 VARBINARY(MAX) = NULL OUTPUT
 as
 begin
-	
+
 	set nocount on
 
 	select CAST( 123456 AS BINARY(4) ) as ''bin'', @in as ''in'', @in2 as ''in2'', @in3 as ''in3'', @in4 as ''in4'', @in5 as ''in5'', @in6 as ''in6''
@@ -78,6 +78,13 @@ begin
 
 	return 0
 
+end')
+
+exec('create procedure [dbo].[__test6]
+	@id UNIQUEIDENTIFIER
+as
+begin
+	return 1
 end')
 
 exec('create type [dbo].[MSSQLTestType] as table(

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -54,6 +54,7 @@ describe('tedious', () => {
     it('binary data', done => TESTS['binary data'](done))
     it('variant data (not yet published)', done => TESTS['variant data'](done))
     it('stored procedure with one empty recordset', done => TESTS['stored procedure with one empty recordset'](done))
+    it('stored procedure calling with invalid type', done => { TESTS['stored procedure calling with invalid type'](done) })
     it('empty query', done => TESTS['empty query'](done))
     it('query with no recordset', done => TESTS['query with no recordset'](done))
     it('query with one recordset', done => TESTS['query with one recordset'](done))


### PR DESCRIPTION
This doesn't seem to occur in the latest version of tedious, but it does happen in v6 of this library. I don't think this should be merged for that reason, but I thought I would let you know about this as an FYI.

This is not critical for me and I only noticed it when I accidentally provided invalid data. I'm code generating my SP call code from the database so I will just generate some extra validation of the arguments before they even hit this code in order to prevent this bug happening on my side.