### PR TITLE
fix geography v2 parsing #322

### DIFF
--- a/lib/udt.js
+++ b/lib/udt.js
@@ -271,7 +271,7 @@ const parseGeography = buffer => {
 
   // console.log( "shapes", shapes)
 
-  if (value.version === 2) {
+  if (value.version === 2 && buffer.position < buffer.length) {
     const numberOfSegments = buffer.readUInt32LE(buffer.position)
     buffer.position += 4
 


### PR DESCRIPTION
fix for #322

Geography parsing would crash on geography version 2 when there is no segment.
According to [the v2 spec](https://docs.microsoft.com/en-us/openspecs/sql_server_protocols/ms-ssclrt/35a20944-9c83-4776-91c6-b5f5af5fef03), the number of segments-bytes are optional, so we have to check the input length.

I've added unit tests to demonstrate the issue.