### PR TITLE
Handle queries that are terminated before all errors are handled

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,8 @@
-v6.3.0 (2020-xx-xx)
+v6.3.0 (2020-12-xx)
 -------------------
 [new] Result sets with duplicate keys can now be handled using `request.arrayRowMode` ([#1130](https://github.com/tediousjs/node-mssql/pull/1130))
 [fix] Issue with geography v2 parsing resolve ([#1138](https://github.com/tediousjs/node-mssql/pull/1138))
+[fix] Fixed issue where msnodesqlv8 could sometimes terminate queries before all errors has been emitted causing queries to hang ([#1145](https://github.com/tediousjs/node-mssql/pull/1145))
 
 v6.2.3 (2020-09-25)
 -------------------

--- a/lib/msnodesqlv8/request.js
+++ b/lib/msnodesqlv8/request.js
@@ -523,6 +523,14 @@ class Request extends BaseRequest {
             serverName: msg.serverName,
             procName: msg.procName
           })
+
+          // query terminated
+          if (msg.code === 3621 && !hasReturned) {
+            // if the query has been terminated it's probably best to throw the last meaningful error if there was one
+            // pop it off the errors array so it doesn't get put in twice
+            const error = errors.length > 0 ? errors.pop() : msg
+            handleError(req, connection, error.originalError || error, false)
+          }
         })
 
         req.on('error', errorHandlers.error = handleError.bind(null, req, connection))


### PR DESCRIPTION
Fixes #1126 

A bit of a hacky fix here, but if the query gets terminated before all the errors are emitted, this ensures the latest error still gets emitted by our library.