### PR TITLE
Fix link to `toReadableStream` section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Parts of the connection URI should be correctly URL encoded so that the URI can 
 * [execute](#execute-procedure-callback)
 * [input](#input-name-type-value)
 * [output](#output-name-type-value)
-* [toReadableStream](#to-readable-stream)
+* [toReadableStream](#toReadableStream)
 * [pipe](#pipe-stream)
 * [query](#query-command-callback)
 * [batch](#batch-batch-callback)


### PR DESCRIPTION
What this does:
Fixes the link in the readme to the new `toReadableStream` section :).
