### PR TITLE
Allow passing in custom value handlers

### DIFF
--- a/lib/tedious/index.js
+++ b/lib/tedious/index.js
@@ -4,12 +4,14 @@ const base = require('../base')
 const ConnectionPool = require('./connection-pool')
 const Transaction = require('./transaction')
 const Request = require('./request')
+const { registerValueHandler } = require('./type-handlers')
 
 module.exports = Object.assign({
   ConnectionPool,
   Transaction,
   Request,
-  PreparedStatement: base.PreparedStatement
+  PreparedStatement: base.PreparedStatement,
+  registerValueHandler
 }, base.exports)
 
 Object.defineProperty(module.exports, 'Promise', {

--- a/lib/tedious/request.js
+++ b/lib/tedious/request.js
@@ -8,6 +8,7 @@ const { IDS, objectHasProperty } = require('../utils')
 const { TYPES, DECLARATIONS, declare, cast } = require('../datatypes')
 const Table = require('../table')
 const { PARSERS: UDT } = require('../udt')
+const { getValueHandler } = require('./type-handlers')
 
 const JSON_COLUMN_ID = 'JSON_F52E2B61-18A1-11d1-B105-00805F49916B'
 const XML_COLUMN_ID = 'XML_F52E2B61-18A1-11d1-B105-00805F49916B'
@@ -159,7 +160,10 @@ const createColumns = function (metadata, arrayRowMode) {
 }
 
 const valueCorrection = function (value, metadata) {
-  if ((metadata.type === tds.TYPES.UDT) && (value != null)) {
+  const valueHandler = getValueHandler(getMssqlType(metadata.type))
+  if (valueHandler) {
+    return valueHandler(value)
+  } else if ((metadata.type === tds.TYPES.UDT) && (value != null)) {
     if (UDT[metadata.udtInfo.typeName]) {
       return UDT[metadata.udtInfo.typeName](value)
     } else {

--- a/lib/tedious/type-handlers.js
+++ b/lib/tedious/type-handlers.js
@@ -1,0 +1,13 @@
+const valueHandlers = {}
+
+export const registerValueHandler = function (type, handler) {
+  if (valueHandlers[type]) {
+    throw new Error('there is already a value handler for: ' + type)
+  }
+
+  valueHandlers[type] = handler
+}
+
+export const getValueHandler = function (type) {
+  return valueHandlers[type]
+}

--- a/lib/tedious/type-handlers.js
+++ b/lib/tedious/type-handlers.js
@@ -1,6 +1,6 @@
 const valueHandlers = {}
 
-export const registerValueHandler = function (type, handler) {
+const registerValueHandler = function (type, handler) {
   if (valueHandlers[type]) {
     throw new Error('there is already a value handler for: ' + type)
   }
@@ -8,6 +8,11 @@ export const registerValueHandler = function (type, handler) {
   valueHandlers[type] = handler
 }
 
-export const getValueHandler = function (type) {
+const getValueHandler = function (type) {
   return valueHandlers[type]
+}
+
+module.exports = {
+  registerValueHandler,
+  getValueHandler
 }


### PR DESCRIPTION
A suggestion for an implementation of #1170.

Related `@types`-change here:
https://github.com/anton-johansson/DefinitelyTyped/commit/9c9565782506d5380f4a2a5fad0f704a5b088e4a

I tried to do some generics-magic to automatically capture the correct type to parse, but I did not get it working properly... It should be possible, but I'm still working my way through TypeScript generics (I'm coming from Java).

Usage example:
```ts
import {registerValueHandler, DateTime, SmallDateTime} from "mssql";
import {toLocalDateTime} from "../utils/date";
import {LocalDateTime} from "@js-joda/core";

registerValueHandler<Date, LocalDateTime>(DateTime, value => toLocalDateTime(value));
registerValueHandler<Date, LocalDateTime>(SmallDateTime, value => toLocalDateTime(value));
```

As you can see, I have to manually specify `Date`, which isn't desirable. I'd love to fix this with proper TypeScript generics capture, but as I mentioned above, I couldn't get it working.

Also, there would be something similar for parameters, but I thought I'd start here.