### PR TITLE
FIX remove bad pool param supplied by knex

### DIFF
--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -3,7 +3,7 @@
 const { EventEmitter } = require('events')
 const debug = require('debug')('mssql:base')
 const tarn = require('tarn')
-const { IDS } = require('../utils')
+const { IDS, objectHasProperty } = require('../utils')
 const ConnectionString = require('../connectionstring')
 const ConnectionError = require('../error/connection-error')
 const shared = require('../shared')
@@ -177,6 +177,11 @@ class ConnectionPool extends EventEmitter {
       this._healthy = true
 
       return this._poolDestroy(connection).then(() => {
+        const poolOpts = this.config.pool
+        if (poolOpts && objectHasProperty(poolOpts, 'evictionRunIntervalMillis')) {
+          delete poolOpts.evictionRunIntervalMillis
+          process.emitWarning('config.pool does not accept "evictionRunIntervalMillis" prop')
+        }
         // prepare pool
         this.pool = new tarn.Pool(
           Object.assign({


### PR DESCRIPTION
related: https://github.com/knex/knex/pull/4235

This will just be a temp fix, but whilst knex is using this bad param we should try to deal with it for best compatibility.

The option being removed hasn't been accepted in the pool arguments since we moved to tarnjs in v6
