### PR TITLE
Add support for TrustedServerCertificate to connection string parsing

### DIFF
--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -2,9 +2,9 @@
 
 const { EventEmitter } = require('events')
 const debug = require('debug')('mssql:base')
+const { parseSqlConnectionString } = require('@tediousjs/connection-string')
 const tarn = require('tarn')
 const { IDS } = require('../utils')
-const ConnectionString = require('../connectionstring')
 const ConnectionError = require('../error/connection-error')
 const shared = require('../shared')
 
@@ -43,7 +43,7 @@ class ConnectionPool extends EventEmitter {
 
     if (typeof config === 'string') {
       try {
-        this.config = ConnectionString.resolve(config, shared.driver.name)
+        this.config = this.parseConnectionString(config)
       } catch (ex) {
         if (typeof callback === 'function') {
           return setImmediate(callback, ex)
@@ -81,6 +81,187 @@ class ConnectionPool extends EventEmitter {
 
   get healthy () {
     return this._healthy
+  }
+
+  parseConnectionString (connectionString) {
+    return this._parseConnectionString(connectionString)
+  }
+
+  _parseConnectionString (connectionString) {
+    const parsed = parseSqlConnectionString(connectionString, true, true)
+    return Object.entries(parsed).reduce((config, [key, value]) => {
+      switch (key) {
+        case 'application name':
+          break
+        case 'applicationintent':
+          Object.assign(config.options, {
+            readOnlyIntent: value === 'readonly'
+          })
+          break
+        case 'asynchronous processing':
+          break
+        case 'attachdbfilename':
+          break
+        case 'authentication':
+          break
+        case 'column encryption setting':
+          break
+        case 'connection timeout':
+          Object.assign(config, {
+            connectionTimeout: value * 1000
+          })
+          break
+        case 'connection lifetime':
+          break
+        case 'connectretrycount':
+          break
+        case 'connectretryinterval':
+          Object.assign(config.options, {
+            connectionRetryInterval: value * 1000
+          })
+          break
+        case 'context connection':
+          break
+        case 'current language':
+          Object.assign(config.options, {
+            language: value
+          })
+          break
+        case 'data source':
+        {
+          let server = value
+          let instanceName
+          let port = 1433
+          if (/^np:/i.test(server)) {
+            throw new Error('Connection via Named Pipes is not supported.')
+          }
+          if (/^tcp:/i.test(server)) {
+            server = server.substr(4)
+          }
+          if (/^(.*)\\(.*)$/.exec(server)) {
+            server = RegExp.$1
+            instanceName = RegExp.$2
+          }
+          if (/^(.*),(.*)$/.exec(server)) {
+            server = RegExp.$1.trim()
+            port = parseInt(RegExp.$2.trim(), 10)
+          }
+          if (server === '.' || server === '(.)' || server.toLowerCase() === '(localdb)' || server.toLowerCase() === '(local)') {
+            server = 'localhost'
+          }
+          Object.assign(config, {
+            port,
+            server
+          })
+          Object.assign(config.options, {
+            instanceName
+          })
+          break
+        }
+        case 'encrypt':
+          Object.assign(config.options, {
+            encrypt: true
+          })
+          break
+        case 'enlist':
+          break
+        case 'failover partner':
+          break
+        case 'initial catalog':
+          Object.assign(config, {
+            database: value
+          })
+          break
+        case 'integrated security':
+          break
+        case 'max pool size':
+          Object.assign(config.pool, {
+            max: value
+          })
+          break
+        case 'min pool size':
+          Object.assign(config.pool, {
+            min: value
+          })
+          break
+        case 'multipleactiveresultsets':
+          break
+        case 'multisubnetfailover':
+          Object.assign(config.options, {
+            multiSubnetFailover: value
+          })
+          break
+        case 'network library':
+          break
+        case 'packet size':
+          Object.assign(config.options, {
+            packetSize: value
+          })
+          break
+        case 'password':
+          Object.assign(config, {
+            password: value
+          })
+          break
+        case 'persist security info':
+          break
+        case 'poolblockingperiod':
+          break
+        case 'pooling':
+          break
+        case 'replication':
+          break
+        case 'transaction binding':
+          Object.assign(config.options, {
+            enableImplicitTransactions: value.toLowerCase() === 'Implicit Unbind'
+          })
+          break
+        case 'transparentnetworkipresolution':
+          break
+        case 'trustservercertificate':
+          Object.assign(config.options, {
+            trustServerCertificate: value
+          })
+          break
+        case 'type system version':
+          break
+        case 'user id': {
+          let user = value
+          let domain
+          if (/^(.*)\\(.*)$/.exec(user)) {
+            domain = RegExp.$1
+            user = RegExp.$2
+          }
+          Object.assign(config, {
+            domain,
+            user
+          })
+          break
+        }
+        case 'user instance':
+          break
+        case 'workstation id':
+          Object.assign(config.options, {
+            workstationId: value
+          })
+          break
+        case 'requesttimeout':
+          Object.assign(config, {
+            requestTimeout: parseInt(value, 10)
+          })
+          break
+        case 'stream':
+          Object.assign(config, {
+            stream: !!value
+          })
+          break
+        case 'useutc':
+          Object.assign(config.options, {
+            useUTC: !!value
+          })
+      }
+      return config
+    }, { options: {}, pool: {} })
   }
 
   /**

--- a/lib/connectionstring.js
+++ b/lib/connectionstring.js
@@ -226,6 +226,12 @@ const resolveConnectionString = function (string, driver) {
     }
   }
 
+  if (parsed.trustservercertificate && ['true', '1', 'yes'].includes(parsed.trustservercertificate.toLowerCase())) {
+    Object.assign(config.options, {
+      trustServerCertificate: true
+    })
+  }
+
   if (parsed.useUTC != null) {
     const utc = parsed.useUTC.toLowerCase()
     config.options.useUTC = utc === 'true' || utc === 'yes' || utc === '1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,11 @@
       "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-3.2.0.tgz",
       "integrity": "sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg=="
     },
+    "@tediousjs/connection-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tediousjs/connection-string/-/connection-string-0.3.0.tgz",
+      "integrity": "sha512-d/keJiNKfpHo+GmSB8QcsAwBx8h+V1UbdozA5TD+eSLXprNY53JAYub47J9evsSKWDdNG5uVj0FiMozLKuzowQ=="
+    },
     "@types/node": {
       "version": "14.14.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.17.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "repository": "github:tediousjs/node-mssql",
   "license": "MIT",
   "dependencies": {
+    "@tediousjs/connection-string": "^0.3.0",
     "debug": "^4",
     "tarn": "^3.0.1",
     "tedious": "^9.2.3"

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -21,13 +21,14 @@ describe('Connection String', () => {
   })
 
   it('Connection String #2', done => {
-    const cfg = cs.resolve('Server=tcp:192.168.0.1,1433;Database=testdb;User Id=testuser;Password=testpwd')
+    const cfg = cs.resolve('Server=tcp:192.168.0.1,1433;Database=testdb;User Id=testuser;Password=testpwd;TrustServerCertificate=true')
 
     assert.strictEqual(cfg.user, 'testuser')
     assert.strictEqual(cfg.password, 'testpwd')
     assert.strictEqual(cfg.database, 'testdb')
     assert.strictEqual(cfg.server, '192.168.0.1')
     assert.strictEqual(cfg.port, 1433)
+    assert.strictEqual(cfg.options.trustServerCertificate, true)
 
     return done()
   })


### PR DESCRIPTION
What this does:

Adds support for the `TrustedServerCertificate` connection string option.