### PR TITLE
Applied fix for BigInts in tagged templates

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -57,8 +57,13 @@ const getTypeByValue = function (value) {
       return TYPES.NVarChar
 
     case 'number':
+    case 'bigint':
       if (value % 1 === 0) {
-        return TYPES.Int
+        if (value < -2147483648 || value > 2147483647) {
+          return TYPES.BigInt
+        } else {
+          return TYPES.Int
+        }
       } else {
         return TYPES.Float
       }


### PR DESCRIPTION
What this does:
Adds the ability to have BigInts (64 bit numbers) in tagged templates.

Fixes: #1197