### PR TITLE
Add support for azure-active-directory-access-token authentication method for tedious driver

### DIFF
--- a/lib/tedious/connection-pool.js
+++ b/lib/tedious/connection-pool.js
@@ -25,11 +25,16 @@ class ConnectionPool extends BaseConnectionPool {
           trustServerCertificate: typeof this.config.trustServerCertificate === 'boolean' ? this.config.trustServerCertificate : false
         }, this.config.options),
         authentication: Object.assign({
-          type: this.config.domain !== undefined ? 'ntlm' : 'default',
+          type: (
+            (this.config.token !== undefined && 'azure-active-directory-access-token') ||
+            (this.config.domain !== undefined && 'ntlm') ||
+            'default'
+          ),
           options: {
             userName: this.config.user,
             password: this.config.password,
-            domain: this.config.domain
+            domain: this.config.domain,
+            token: this.config.token
           }
         }, this.config.authentication)
       }


### PR DESCRIPTION
This change allows to use [`azure-active-directory-access-token`](https://github.com/tediousjs/tedious/blob/f6e1681873fd792ba07a854f276a1761f8a8401e/src/connection.ts#L237) authentication method when `token` value would be passed in the `options` object.

It is required to implement authenticating to the MSSQL database using Access Token.

Here is a link to the Microsoft Documentation about AD Access Token:
https://docs.microsoft.com/en-us/azure/azure-sql/database/authentication-aad-configure?tabs=azure-powershell#azure-ad-token
