### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supported TDS drivers:
 
     npm install mssql
 
-## Quick Example
+## Short Example: Use Connect String
 
 ```javascript
 const sql = require('mssql')
@@ -32,6 +32,56 @@ async () => {
 If you're on Windows Azure, add `?encrypt=true` to your connection string. See [docs](#configuration) to learn more.
 
 Parts of the connection URI should be correctly URL encoded so that the URI can be parsed correctly.
+
+## Longer Example: Connect via Config Object
+```javascript
+/* mssql_connection_test.js */
+require('dotenv').config()
+const sql = require('mssql');
+
+const mssql_config = {
+  user: process.env['DB_USER'] ,
+  password: process.env['DB_PWD'],
+  database: process.env['DB_NAME'],
+  server: 'localhost',
+  pool: {
+    max: 10,
+    min: 0,
+    idleTimeoutMillis: 30000
+  },
+  options: {
+    "enableArithAbort": true,
+    "encrypt": true
+  }
+}
+
+async function mssql_test_connect() {
+  try {
+    await sql.connect(mssql_config);
+    const result = await sql.query `select 1`
+    console.dir(result)
+  } catch (err) {
+      console.warn(`Error connecting to mssql: ${err}`);
+  }
+}
+
+/* Run immediately if called from command line: */
+if (!module.parent) {
+  (async () => {
+    await mssql_test_connect();
+    await sql.close();
+    console.log("Connection Closed")
+  })();
+}
+```
+
+To use: 
+1. setup a .dotenv file with user, password and database name, and install dotenv module to populate process.env
+2. run from the command line: `node mssql_connection_test.js`
+
+This example sets encrypt to true for compatability with Windows Azure, but will also work on a local Docker instance.
+
+The default value for `config.options.enableArithAbort` will change from `false` to `true` in the next major version of `tedious`,so in this example it is set explicitly to avoide the `deprecation` warning.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ If you're on Windows Azure, add `?encrypt=true` to your connection string. See [
 Parts of the connection URI should be correctly URL encoded so that the URI can be parsed correctly.
 
 ## Longer Example: Connect via Config Object
-```javascript
-/* mssql_connection_test.js */
-require('dotenv').config()
-const sql = require('mssql');
 
-const mssql_config = {
-  user: process.env['DB_USER'] ,
-  password: process.env['DB_PWD'],
-  database: process.env['DB_NAME'],
+Assuming you have set the appropriate environment variables, you can construct a config object as follows:
+
+```javascript
+const sql = require('mssql')
+const sqlConfig = {
+  user: process.env.DB_USER,
+  password: process.env.DB_PWD,
+  database: process.env.DB_NAME,
   server: 'localhost',
   pool: {
     max: 10,
@@ -50,38 +50,22 @@ const mssql_config = {
     idleTimeoutMillis: 30000
   },
   options: {
-    "enableArithAbort": true,
-    "encrypt": true
+    encrypt: true, // for azure
+    trustServerCertificate: false // change to true for local dev / self-signed certs
   }
 }
 
-async function mssql_test_connect() {
-  try {
-    await sql.connect(mssql_config);
-    const result = await sql.query `select 1`
-    console.dir(result)
-  } catch (err) {
-      console.warn(`Error connecting to mssql: ${err}`);
-  }
-}
-
-/* Run immediately if called from command line: */
-if (!module.parent) {
-  (async () => {
-    await mssql_test_connect();
-    await sql.close();
-    console.log("Connection Closed")
-  })();
+async () => {
+ try {
+  // make sure that any items are correctly URL encoded in the connection string
+  await sql.connect(sqlConfig)
+  const result = await sql.query`select * from mytable where id = ${value}`
+  console.dir(result)
+ } catch (err) {
+  // ... error checks
+ }
 }
 ```
-
-To use: 
-1. setup a .dotenv file with user, password and database name, and install dotenv module to populate process.env
-2. run from the command line: `node mssql_connection_test.js`
-
-This example sets encrypt to true for compatability with Windows Azure, but will also work on a local Docker instance.
-
-The default value for `config.options.enableArithAbort` will change from `false` to `true` in the next major version of `tedious`,so in this example it is set explicitly to avoide the `deprecation` warning.
 
 ## Documentation
 


### PR DESCRIPTION
To save others time, I've added a short example that uses the config object instead of the connection string, and also shows where to set the value for `enableArithAbort` in the config file.    The purpose is to get folks up and running a bit quicker without having to hunt down some minor problems out of the gate.  

Also, for convenience, it runs from the command line to check the connection.

What this does:
