### PR TITLE
Update docs around uri connection strings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ v7.0.0 (2021-05-06)
 [fix] Trailing rows from request streams using msnodesqlv8 driver fail to be emitted ([#1109](https://github.com/tediousjs/node-mssql/pull/1109))
 [fix] Issue with geography v2 parsing resolve ([#1138](https://github.com/tediousjs/node-mssql/pull/1138))
 [fix] Connection config objects are now deep cloned when stored against a connection pool ([#1217](https://github.com/tediousjs/node-mssql/pull/1217))
+[removed] Support for connection uri format has been removed (eg: `mssql://user:password@host/?params=values`
 
 v6.3.1 (2021-01-01)
 -------------------

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const sql = require('mssql')
 async () => {
     try {
         // make sure that any items are correctly URL encoded in the connection string
-        await sql.connect('mssql://username:password@localhost/database')
+        await sql.connect('Server=localhost,1433;Database=database;User Id=username;Password=password;Encrypt=true')
         const result = await sql.query`select * from mytable where id = ${value}`
         console.dir(result)
     } catch (err) {
@@ -660,20 +660,13 @@ Complete list of pool options can be found [here](https://github.com/vincit/tarn
 
 ### Formats
 
-In addition to configuration object there is an option to pass config as a connection string. Two formats of connection string are supported.
+In addition to configuration object there is an option to pass config as a connection string. Connection strings are supported.
 
 ##### Classic Connection String
 
 ```
 Server=localhost,1433;Database=database;User Id=username;Password=password;Encrypt=true
 Driver=msnodesqlv8;Server=(local)\INSTANCE;Database=database;UID=DOMAIN\username;PWD=password;Encrypt=true
-```
-
-##### Connection String URI
-
-```
-mssql://username:password@localhost:1433/database?encrypt=true
-mssql://username:password@localhost/INSTANCE/database?encrypt=true&domain=DOMAIN&driver=msnodesqlv8
 ```
 
 ## Drivers


### PR DESCRIPTION
What this does:

see #1230 - "upgraded" connection string library doesn't support URI connection strings (for now)