### PR TITLE
Catch errors thrown by new tds.Connection()

### DIFF
--- a/lib/tedious/connection-pool.js
+++ b/lib/tedious/connection-pool.js
@@ -59,7 +59,13 @@ class ConnectionPool extends BaseConnectionPool {
           payload: true
         }
       }
-      const tedious = new tds.Connection(cfg)
+      let tedious
+      try {
+        tedious = new tds.Connection(cfg)
+      } catch (err) {
+        rejectOnce(err)
+        return
+      }
       tedious.connect(err => {
         if (err) {
           err = new ConnectionError(err)


### PR DESCRIPTION
What this does:

Ensures errors from tedious connection creation are caught and cause the promise to reject