### PR TITLE
chore: add `devcontainer` configuration

### DIFF
--- a/.devcontainer/.mssql.json
+++ b/.devcontainer/.mssql.json
@@ -1,0 +1,12 @@
+{
+  "user": "sa",
+  "password": "yourStrong(!)Password",
+  "server": "mssql",
+  "port": 1433,
+  "database": "master",
+  "requestTimeout": 30000,
+  "options": {
+    "abortTransactionOnError": true,
+    "encrypt": false
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "tediousjs/node-mssql",
+
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+
+  "workspaceFolder": "/workspace",
+
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+
+  "extensions": [
+    "ms-mssql.mssql",
+    "dbaeumer.vscode-eslint"
+  ],
+
+  "postCreateCommand": "npm install",
+
+  "containerEnv": {
+    "EDITOR": "code --wait"
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  app:
+    image: "mcr.microsoft.com/vscode/devcontainers/javascript-node:14"
+
+    volumes:
+      - "..:/workspace:cached"
+      - "./.mssql.json:/workspace/test/.mssql.json"
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: "sleep infinity"
+
+    depends_on:
+      - mssql
+
+  mssql:
+    image: "mcr.microsoft.com/mssql/server:2019-latest"
+
+    restart: unless-stopped
+
+    environment:
+      - "ACCEPT_EULA=Y"
+      - "SA_PASSWORD=yourStrong(!)Password"


### PR DESCRIPTION
What this does:

This adds a `devcontainer` configuration that allows to easily get a development environment for `node-mssql` up and running.

See https://code.visualstudio.com/docs/remote/containers for more information.