### PR TITLE
chore: fix the devcontainer configuration to work with local development containers and GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     "dbaeumer.vscode-eslint"
   ],
 
-  "postCreateCommand": "npm install",
+  "postCreateCommand": "cp -n .devcontainer/.mssql.json test/.mssql.json && npm install",
 
   "containerEnv": {
     "EDITOR": "code --wait"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,6 @@ services:
 
     volumes:
       - "..:/workspace:cached"
-      - "./.mssql.json:/workspace/test/.mssql.json"
 
     # Overrides default command so things don't shut down after the process ends.
     command: "sleep infinity"


### PR DESCRIPTION
What this does:

This changes the devcontainer configuration to work both in local VS Code containers as well as GitHub Codespaces. GitHub Codespaces do not support the `workspaceFolder` option yet, so after starting a Codespace we'd end up in a different folder that contained the `node-mssql` source code, but did not have the `test/.mssql.json` configuration properly set up.

Instead of using a docker volume to map the `.mssql.json` file into the correct location, we just copy it over on container creation, unless it is already there.