### PR TITLE
Use a different driver in the msnodesqlv8 when on linux/mac

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 v8.0.0 (2021-??-??)
 -------------------
-[change] Updated to latest Tedious 14 ((#1318)[https://github.com/tediousjs/node-mssql/pull/1318])
+[change] msnodesqlv8 driver detects os platform and attempts to pick correct connections string for it ((#1318)[https://github.com/tediousjs/node-mssql/pull/1318])
+[change] Updated to latest Tedious 14 ((#1312)[https://github.com/tediousjs/node-mssql/pull/1312])
 [change] Errors for bad bulk load parameters have slightly different error messages ((#1318)[https://github.com/tediousjs/node-mssql/pull/1318])
 
 v7.2.1 (2021-08-19)

--- a/lib/msnodesqlv8/connection-pool.js
+++ b/lib/msnodesqlv8/connection-pool.js
@@ -6,9 +6,11 @@ const BaseConnectionPool = require('../base/connection-pool')
 const { IDS, INCREMENT } = require('../utils')
 const shared = require('../shared')
 const ConnectionError = require('../error/connection-error')
+const { platform } = require('os')
 
-const CONNECTION_STRING_PORT = 'Driver=SQL Server Native Client 11.0;Server=#{server},#{port};Database=#{database};Uid=#{user};Pwd=#{password};Trusted_Connection=#{trusted};Encrypt=#{encrypt};'
-const CONNECTION_STRING_NAMED_INSTANCE = 'Driver=SQL Server Native Client 11.0;Server=#{server}\\#{instance};Database=#{database};Uid=#{user};Pwd=#{password};Trusted_Connection=#{trusted};Encrypt=#{encrypt};'
+const CONNECTION_DRIVER = ['darwin', 'linux'].includes(platform()) ? 'ODBC Driver 17 for SQL Server' : 'SQL Server Native Client 11.0'
+const CONNECTION_STRING_PORT = `Driver=${CONNECTION_DRIVER};Server=#{server},#{port};Database=#{database};Uid=#{user};Pwd=#{password};Trusted_Connection=#{trusted};Encrypt=#{encrypt};`
+const CONNECTION_STRING_NAMED_INSTANCE = `Driver=${CONNECTION_DRIVER};Server=#{server}\\#{instance};Database=#{database};Uid=#{user};Pwd=#{password};Trusted_Connection=#{trusted};Encrypt=#{encrypt};`
 
 class ConnectionPool extends BaseConnectionPool {
   _poolCreate () {


### PR DESCRIPTION
What this does:
Uses a different driver in the connection string when on macos/linux than on windows so that it's possible to use the library on those systems with msnodesqlv8.

This should fix the issue #1290 