### PR TITLE
Request should use this.parent not this.connection

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+v6.4.0 (2021-11-18)
+-------------------
+[new] Transaction/PreparedStatements expose the config from their parent connection
+[fix] Fix inherited request configs from the pool. Specifically stream and arrayRowMode now inherit accurately from the connection config ([#1338](https://github.com/tediousjs/node-mssql/pull/1338))
+
 v6.3.2 (2021-05-13)
 -------------------
 [fix] Bump various dependencies for security fixes

--- a/lib/base/prepared-statement.js
+++ b/lib/base/prepared-statement.js
@@ -35,6 +35,10 @@ class PreparedStatement extends EventEmitter {
     this.parameters = {}
   }
 
+  get config () {
+    return this.parent.config
+  }
+
   get connected () {
     return this.parent.connected
   }

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -38,6 +38,8 @@ class Request extends EventEmitter {
     this._paused = false
     this.parent = parent || globalConnection.pool
     this.parameters = {}
+    this.stream = null
+    this.arrayRowMode = null
   }
 
   get paused () {
@@ -223,8 +225,8 @@ class Request extends EventEmitter {
    */
 
   batch (batch, callback) {
-    if (this.stream == null && this.connection) this.stream = this.connection.config.stream
-    if (this.arrayRowMode == null && this.connection) this.arrayRowMode = this.connection.config.arrayRowMode
+    if (this.stream === null && this.parent) this.stream = this.parent.config.stream
+    if (this.arrayRowMode === null && this.parent) this.arrayRowMode = this.parent.config.arrayRowMode
     this.rowsAffected = 0
 
     if (typeof callback === 'function') {
@@ -287,11 +289,11 @@ class Request extends EventEmitter {
    */
 
   _batch (batch, callback) {
-    if (!this.connection) {
+    if (!this.parent) {
       return setImmediate(callback, new RequestError('No connection is specified for that request.', 'ENOCONN'))
     }
 
-    if (!this.connection.connected) {
+    if (!this.parent.connected) {
       return setImmediate(callback, new ConnectionError('Connection is closed.', 'ECONNCLOSED'))
     }
 
@@ -316,8 +318,8 @@ class Request extends EventEmitter {
       options = {}
     }
 
-    if (this.stream == null && this.connection) this.stream = this.connection.config.stream
-    if (this.arrayRowMode == null && this.connection) this.arrayRowMode = this.connection.config.arrayRowMode
+    if (this.stream === null && this.parent) this.stream = this.parent.config.stream
+    if (this.arrayRowMode === null && this.parent) this.arrayRowMode = this.parent.config.arrayRowMode
 
     if (this.stream || typeof callback === 'function') {
       this._bulk(table, options, (err, rowsAffected) => {
@@ -393,8 +395,8 @@ class Request extends EventEmitter {
    */
 
   query (command, callback) {
-    if (this.stream == null && this.connection) this.stream = this.connection.config.stream
-    if (this.arrayRowMode == null && this.connection) this.arrayRowMode = this.connection.config.arrayRowMode
+    if (this.stream === null && this.parent) this.stream = this.parent.config.stream
+    if (this.arrayRowMode === null && this.parent) this.arrayRowMode = this.parent.config.arrayRowMode
     this.rowsAffected = 0
 
     if (typeof callback === 'function') {
@@ -482,8 +484,8 @@ class Request extends EventEmitter {
    */
 
   execute (command, callback) {
-    if (this.stream == null && this.connection) this.stream = this.connection.config.stream
-    if (this.arrayRowMode == null && this.connection) this.arrayRowMode = this.connection.config.arrayRowMode
+    if (this.stream === null && this.parent) this.stream = this.parent.config.stream
+    if (this.arrayRowMode === null && this.parent) this.arrayRowMode = this.parent.config.arrayRowMode
     this.rowsAffected = 0
 
     if (typeof callback === 'function') {

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -25,7 +25,7 @@ class Request extends EventEmitter {
   /**
    * Create new Request.
    *
-   * @param {Connection|ConnectionPool|Transaction|PreparedStatement} parent If ommited, global connection is used instead.
+   * @param {Connection|ConnectionPool|Transaction|PreparedStatement} parent If omitted, global connection is used instead.
    */
 
   constructor (parent) {

--- a/lib/base/transaction.js
+++ b/lib/base/transaction.js
@@ -37,6 +37,10 @@ class Transaction extends EventEmitter {
     this.name = ''
   }
 
+  get config () {
+    return this.parent.config
+  }
+
   get connected () {
     return this.parent.connected
   }


### PR DESCRIPTION
What this does:

Yikes - I did some debugging related to #1292 and it was clear that the checks we are doing are not very sensible.

1. Give `request.stream` and `request.arrayRowMode` default values of `null`
2. Only change the value of the specific request instance's `stream` or `arrayRowMode` prop *if* it's supplied by the `parent` config.
3. Replace usage of the non-existent `this.connection` with `this.parent` for `Request` instances 🤦‍♂️ 

Related issues:

#1292 

Pre/Post merge checklist:

- [x] Update change log
