### PR TITLE
Remove deprecated pool properties

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ v8.0.0 (2022-??-??)
 [change] Duplicate column names will now be presented as an array even if the values are empty ((#1240)[https://github.com/tediousjs/node-mssql/pull/1240])
 [change] Update tarn pool dependency ((#1344)[https://github.com/tediousjs/node-mssql/pull/1344])
 [removed] Remove connection string parser helpers ((#1342)[https://github.com/tediousjs/node-mssql/pull/1342])
+[removed] Remove deprecated pool properties ((#1359)[https://github.com/tediousjs/node-mssql/pull/1359])
 
 v7.2.1 (2021-08-19)
 -------------------

--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -388,41 +388,6 @@ class ConnectionPool extends EventEmitter {
             propagateCreateError: true
           }, this.config.pool)
         )
-        const self = this
-        Object.defineProperties(this.pool, {
-          size: {
-            get: () => {
-              const message = 'the `size` property on pool is deprecated, access it directly on the `ConnectionPool`'
-              self.emit('debug', message)
-              process.emitWarning(message)
-              return self.size
-            }
-          },
-          available: {
-            get: () => {
-              const message = 'the `available` property on pool is deprecated, access it directly on the `ConnectionPool`'
-              self.emit('debug', message)
-              process.emitWarning(message)
-              return self.available
-            }
-          },
-          pending: {
-            get: () => {
-              const message = 'the `pending` property on pool is deprecate, access it directly on the `ConnectionPool`'
-              self.emit('debug', message)
-              process.emitWarning(message)
-              return self.pending
-            }
-          },
-          borrowed: {
-            get: () => {
-              const message = 'the `borrowed` property on pool is deprecated, access it directly on the `ConnectionPool`'
-              self.emit('debug', message)
-              process.emitWarning(message)
-              return self.borrowed
-            }
-          }
-        })
 
         this._connecting = false
         this._connected = true


### PR DESCRIPTION
What this does:

Remove pool properties that were deprecated in v5

Related issues:

N/A

Pre/Post merge checklist:

- [x] Update change log
