### PR TITLE
Prep for v6 end of life

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+v6.4.1 (2022-02-??)
+-------------------
+[fix] Bump debug dependency ([#1361](https://github.com/tediousjs/node-mssql/pull/1361))
+
 v6.4.0 (2021-11-18)
 -------------------
 [new] Transaction/PreparedStatements expose the config from their parent connection

--- a/package-lock.json
+++ b/package-lock.json
@@ -445,9 +445,9 @@
       "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "requires": {
         "ms": "2.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "repository": "github:tediousjs/node-mssql",
   "license": "MIT",
   "dependencies": {
-    "debug": "^4.3.2",
+    "debug": "^4.3.3",
     "tarn": "^1.1.5",
     "tedious": "^6.7.1"
   },


### PR DESCRIPTION
What this does:

1. Minor bump to debug library
2. Use the tedious Connection.reset() function when releasing connections back to the pool

Related issues:

N/A

Pre/Post merge checklist:

- [x] Update change log
