### PR TITLE
CI Support for msnodesqlv8 on node 10

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,17 @@
+Unreleased changes
+-------------------
+[fix] nodemsqlv8 driver tests working against Node 10 ([#1368](https://github.com/tediousjs/node-mssql/pull/1368))
+
+v8.0.2 (2022-02-07)
+-------------------
+Merge up missing fixes from v7.3.0
+[new] Transaction/PreparedStatements expose the config from their parent connection ([#1338](https://github.com/tediousjs/node-mssql/pull/1338))
+[fix] Fix inherited request configs from the pool. Specifically stream and arrayRowMode now inherit accurately from the connection config ([#1338](https://github.com/tediousjs/node-mssql/pull/1338))
+
+v8.0.1 (2022-01-30)
+-------------------
+Re-release of v8.0.0
+
 v8.0.0 (2022-01-30)
 -------------------
 [new] Add table.rows.clear() method to allow for chunking updates ([#1094](https://github.com/tediousjs/node-mssql/pull/1094))
@@ -13,7 +27,7 @@ v8.0.0 (2022-01-30)
 
 v7.3.0 (2021-11-18)
 -------------------
-[new] Transaction/PreparedStatements expose the config from their parent connection
+[new] Transaction/PreparedStatements expose the config from their parent connection ([#1338](https://github.com/tediousjs/node-mssql/pull/1338))
 [fix] Fix inherited request configs from the pool. Specifically stream and arrayRowMode now inherit accurately from the connection config ([#1338](https://github.com/tediousjs/node-mssql/pull/1338))
 
 v7.2.1 (2021-08-19)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
   # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - npm install
-  - npm install msnodesqlv8@^2
+  - IF %nodejs_version% GTR 10 (npm install msnodesqlv8@^2) ELSE (npm install msnodesqlv8@2.4.4)
 
 platform:
   - x86


### PR DESCRIPTION
What this does:

See https://github.com/TimelordUK/node-sqlserver-v8/issues/232

msnodesqlv8 accidentally broke Node 10 support in 2.4.5 release. This change conditionally installs the 2.4.4 version if testing on Node 10

Related issues:

https://github.com/TimelordUK/node-sqlserver-v8/issues/232

Pre/Post merge checklist:

- [x] Update change log
