### PR TITLE
Escape single quotes in the input query

### DIFF
--- a/lib/global-connection.js
+++ b/lib/global-connection.js
@@ -140,7 +140,7 @@ function removeListener (event, handler) {
  */
 
 function query () {
-  if (typeof arguments[0] === 'string') { return new shared.driver.Request().query(arguments[0], arguments[1]) }
+  if (typeof arguments[0] === 'string') { return new shared.driver.Request().query(arguments[0].replace("'", "''"), arguments[1]) }
 
   const values = Array.prototype.slice.call(arguments)
   const strings = values.shift()


### PR DESCRIPTION
What this does:

I recently got into a situation where people were adding single quote. And when I added that to the database inside the query, it throws an error. To fix this issue, I replaced the single quotes directly in the library

Related issues:

None

Pre/Post merge checklist:

- [ ] Update change log
