### PR TITLE
add square brackets to primary keys

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -99,7 +99,7 @@ Table.prototype._makeBulk = function _makeBulk () {
 }
 
 Table.prototype.declare = function declare () {
-  const pkey = this.columns.filter(col => col.primary === true).map(col => col.name)
+  const pkey = this.columns.filter(col => col.primary === true).map(col => `[${col.name}]`)
   const cols = this.columns.map(col => {
     const def = [`[${col.name}] ${declareType(col.type, col)}`]
 

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -91,7 +91,7 @@ describe('Unit', () => {
     t.columns.add('a', sql.Int, { primary: true })
     t.columns.add('b', sql.TinyInt, { nullable: true })
     t.columns.add('c', sql.TinyInt, { nullable: false, primary: true })
-    assert.strictEqual(t.declare(), 'create table [#mytemptable] ([a] int, [b] tinyint null, [c] tinyint not null, constraint PK_mytemptable primary key (a, c))')
+    assert.strictEqual(t.declare(), 'create table [#mytemptable] ([a] int, [b] tinyint null, [c] tinyint not null, constraint PK_mytemptable primary key ([a], [c]))')
 
     t = new sql.Table('MyTable')
     t.columns.add('name', sql.NVarChar, {


### PR DESCRIPTION
What this does:

Added square brackets to primary keys when creating the table.

This prevents errors when using special characters in the column name.

- [ ] Update change log