### PR TITLE
fix: requestTimeout option

### DIFF
--- a/lib/tedious/connection-pool.js
+++ b/lib/tedious/connection-pool.js
@@ -37,7 +37,7 @@ class ConnectionPool extends BaseConnectionPool {
       cfg.options.database = cfg.options.database || this.config.database
       cfg.options.port = cfg.options.port || this.config.port
       cfg.options.connectTimeout = cfg.options.connectTimeout || this.config.connectionTimeout || this.config.timeout || 15000
-      cfg.options.requestTimeout = cfg.options.requestTimeout || this.config.requestTimeout != null ? this.config.requestTimeout : 15000
+      cfg.options.requestTimeout = cfg.options.requestTimeout || this.config.requestTimeout || this.config.timeout || 15000
       cfg.options.tdsVersion = cfg.options.tdsVersion || '7_4'
       cfg.options.rowCollectionOnDone = cfg.options.rowCollectionOnDone || false
       cfg.options.rowCollectionOnRequestCompletion = cfg.options.rowCollectionOnRequestCompletion || false


### PR DESCRIPTION
What this does:

The `requestTimeout` options is not properly handled/accounted for.

Related issues:

#1396 

Pre/Post merge checklist:

- [ ] Update change log
