### PR TITLE
chore(msnodesqlv8/request): remove superfluous arg

### DIFF
--- a/lib/msnodesqlv8/request.js
+++ b/lib/msnodesqlv8/request.js
@@ -369,7 +369,7 @@ class Request extends BaseRequest {
           }
           const param = this.parameters[name]
           if (param.io === 1 || (param.io === 2 && param.value)) {
-            params.push(castParameter(param.value, param.type, param))
+            params.push(castParameter(param.value, param.type))
           }
         }
 


### PR DESCRIPTION
What this does:

Removes superfluous arg from `castParameter()` call.
It only accepts two args:

https://github.com/tediousjs/node-mssql/blob/b9382d425726ecdaf29972e20e1c0e115cbd8856/lib/msnodesqlv8/request.js#L17


<!-- Describe the PR -->

Related issues:

N/A

<!-- Provide links to any related issues or issues being closed by this PR -->

Pre/Post merge checklist:

- [ ] Update change log
