### PR TITLE
Deny support for `useColumnNames` tedious option

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 Unreleased
 -------------------
 [fix] requestTimeout correctly resolved ([#1398](https://github.com/tediousjs/node-mssql/pull/1398))
+[fix] Forcibly deny use of `useColumnNames` tedious config option that can be passed in the config object ([#1416](https://github.com/tediousjs/node-mssql/pull/1416))
 
 v8.1.2 (2022-05-27)
 -------------------

--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -8,6 +8,7 @@ const { IDS } = require('../utils')
 const ConnectionError = require('../error/connection-error')
 const shared = require('../shared')
 const clone = require('rfdc/default')
+const { MSSQLError } = require('../error')
 
 /**
  * Class ConnectionPool.
@@ -66,6 +67,14 @@ class ConnectionPool extends EventEmitter {
     if (/^(.*)\\(.*)$/.exec(this.config.server)) {
       this.config.server = RegExp.$1
       this.config.options.instanceName = RegExp.$2
+    }
+
+    if (typeof this.config.options.useColumnNames !== 'undefined' && this.config.options.useColumnNames !== true) {
+      const ex = new MSSQLError('Invalid options `useColumnNames`, use `arrayRowMode` instead')
+      if (typeof callback === 'function') {
+        return setImmediate(callback, ex)
+      }
+      throw ex
     }
 
     if (typeof callback === 'function') {

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -48,7 +48,7 @@ class Request extends EventEmitter {
   }
 
   /**
-   * Generate sql string and set imput parameters from tagged template string.
+   * Generate sql string and set input parameters from tagged template string.
    *
    * @param {Template literal} template
    * @return {String}

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -44,6 +44,7 @@ describe('msnodesqlv8', function () {
       sql.connect(cfg, done)
     })
 
+    it('config validation', done => TESTS['config validation'](done))
     it('value handler', done => TESTS['value handler'](done))
     it('stored procedure (exec)', done => TESTS['stored procedure']('execute', done))
     it('stored procedure (batch)', done => TESTS['stored procedure']('batch', done))

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -51,6 +51,7 @@ describe('tedious', () => {
       sql.connect(cfg, done)
     })
 
+    it('config validation', done => TESTS['config validation'](done))
     it('value handler', done => TESTS['value handler'](done))
     it('stored procedure (exec)', done => TESTS['stored procedure']('execute', done))
     it('stored procedure (batch)', done => TESTS['stored procedure']('batch', done))


### PR DESCRIPTION
What this does:

This throws an error if the `useColumnNames` connection option is passed via the config object. See #1413. This option causes errors in the library, so throwing here is not a breaking change, it just gives a more helpful error.

Users should use `arrayRowMode` config instead

Pre/Post merge checklist:

- [x] Update change log
