### PR TITLE
Fixing small typo in connecting with express documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ Then the route uses the connection pool in the `app.locals` object:
 const sql = require('mssql');
 
 module.exports = function(req, res) {
-  req.locals.db.query('SELECT TOP 10 * FROM table_name', function(err, recordset) {
+  req.app.locals.db.query('SELECT TOP 10 * FROM table_name', function(err, recordset) {
     if (err) {
       console.error(err)
       res.status(500).send('SERVER ERROR')


### PR DESCRIPTION
What this does:

Small typo. According to the express docs and my own application apps.locals can be accessed through req.app.locals not req.locals.

Pre/Post merge checklist:

- [ ] Update change log
