### PR TITLE
Added support for AAD authentication via connection string

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+v9.?.? (2022-??-??)
+-------------------
+[new] Add support for AAD authentication via connection string ((#1436)[https://github.com/tediousjs/node-mssql/pull/1436])
+
 v9.0.1 (2022-08-18)
 -------------------
 [fix] fix regression in requestTimout option not accepting `0` as a value ([#1421](https://github.com/tediousjs/node-mssql/pull/1421))

--- a/README.md
+++ b/README.md
@@ -571,10 +571,34 @@ Complete list of pool options can be found [here](https://github.com/vincit/tarn
 In addition to configuration object there is an option to pass config as a connection string. Connection strings are supported.
 
 ##### Classic Connection String
+###### Standard configuration using tedious driver
 
 ```
 Server=localhost,1433;Database=database;User Id=username;Password=password;Encrypt=true
+```
+###### Standard configuration using msnodesqlv8 driver
+```
 Driver=msnodesqlv8;Server=(local)\INSTANCE;Database=database;UID=DOMAIN\username;PWD=password;Encrypt=true
+```
+
+##### Azure Active Directory Authentication Connection String
+
+Several types of Azure Authentication are supported:
+###### Authentication using Default Azure Credentials
+```
+Server=*.database.windows.net;Database=database;Authentication=azure-active-directory-default;ClientID=clientid;Encrypt=true
+```
+###### Authentication using Active Directory Password
+```
+Server=*.database.windows.net;Database=database;Authentication=azure-active-directory-password;User Id=username;Password=password;ClientID=clientid;TenantID=tenantid;Encrypt=true
+```
+###### Authentication using Access Token
+```
+Server=*.database.windows.net;Database=database;Authentication=azure-active-directory-access-token;Token=token;Encrypt=true
+```
+###### Authentication using Service Principal
+```
+Server=*.database.windows.net;Database=database;Authentication=azure-active-directory-service-principal-secret;ClientID=clientid;ClientSecret=clientsecret;TenantID=tenantid;Encrypt=true
 ```
 
 ## Drivers

--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -114,6 +114,9 @@ class ConnectionPool extends EventEmitter {
         case 'attachdbfilename':
           break
         case 'authentication':
+          Object.assign(config.authentication, {
+            type: value
+          })
           break
         case 'column encryption setting':
           break
@@ -132,6 +135,16 @@ class ConnectionPool extends EventEmitter {
           })
           break
         case 'context connection':
+          break
+        case 'client id':
+          Object.assign(config.authentication.options, {
+            clientId: value
+          })
+          break
+        case 'client secret':
+          Object.assign(config.authentication.options, {
+            clientSecret: value
+          })
           break
         case 'current language':
           Object.assign(config.options, {
@@ -222,6 +235,16 @@ class ConnectionPool extends EventEmitter {
           break
         case 'replication':
           break
+        case 'tenant id':
+          Object.assign(config.authentication.options, {
+            tenantId: value
+          })
+          break
+        case 'token':
+          Object.assign(config.authentication.options, {
+            token: value
+          })
+          break
         case 'transaction binding':
           Object.assign(config.options, {
             enableImplicitTransactions: value.toLowerCase() === 'implicit unbind'
@@ -278,7 +301,7 @@ class ConnectionPool extends EventEmitter {
           break
       }
       return config
-    }, { options: {}, pool: {} })
+    }, { authentication: { options: {} }, options: {}, pool: {} })
   }
 
   /**


### PR DESCRIPTION
What this does:

This PR adds several fields related to AAD authentication. The ones added on this PR are:

1. Authentication - dictating the authentication type
2. Client ID/ClientID - used when authenticating via AAD service principal
3. Client Secret/ClientSecret - used when authenticating via AAD service principal
4. Tenant ID/TenantID  - used when authenticating via AAD service principal
5. Token - used when authenticating via AAD access token

I am completely open in renaming these fields to whichever feels more appropriate but feedback is more than welcome.

This PR is going to accomodate issue #1400 