### PR TITLE
Fix README to show node 12 no longer supported with 9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2030,7 +2030,7 @@ request.query('select @myval as myval', (err, result) => {
 ## 8.x to 9.x changes
 
 - Upgraded to tedious version 15
-- Dropped support for Node version < 12
+- Dropped support for Node version <= 12
 
 ## 7.x to 8.x changes
 


### PR DESCRIPTION
What this does:

The README showed that node < 12 support was dropped with 9.x, but based on commit 644480535933aa21d3c0677965656dc21f2949c6 it shows that node <= 12 (including node 12) support was dropped and the release notes associated with the version show the same. Updates README to align with commit message and release notes.

Related issues:

N/A

Pre/Post merge checklist:

- [ ] Update change log
