### PR TITLE
:bug: quote sqlv8 values

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+v9.1.3 (2023-??-??)
+-------------------
+[fix] Escape values that are added to the msnodesqlv8 connection string that we construct ((#1479)[https://github.com/tediousjs/node-mssql/pull/1479])
+
 v9.1.2 (2023-08-01)
 -------------------
 [fix] Support more named instance formats ([#1520](https://github.com/tediousjs/node-mssql/pull/1520))

--- a/lib/msnodesqlv8/connection-pool.js
+++ b/lib/msnodesqlv8/connection-pool.js
@@ -38,8 +38,15 @@ class ConnectionPool extends BaseConnectionPool {
             return this.config.options.trustedConnection ? 'Yes' : 'No'
           case 'encrypt':
             return this.config.options.encrypt ? 'Yes' : 'No'
-          default:
-            return this.config[key] != null ? this.config[key] : ''
+          default: {
+            let val = this.config[key] || ''
+            // quote strings that contain '{' or '}' but not ones that start and end with them (assume they are already quoted)
+            if (val && typeof val === 'string' && !(val.startsWith('{') && val.endsWith('}')) && (val.indexOf('{') !== -1 || val.indexOf('}') !== -1)) {
+              // quote values in `{}` and escape any existing `}` chars
+              val = `{${val.replace(/}/g, '}}')}}`
+            }
+            return val
+          }
         }
       })
 


### PR DESCRIPTION
What this does:

This quotes generic arguments for the constructed connection string that is passed to msnodesqlv8; previous special chars in fields like password could end up breaking the connection string.

Related issues:

Fixes #1476

Pre/Post merge checklist:

- [x] Update change log
