### PR TITLE
deps: update tedious to v16.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "@azure/core-client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.6.1.tgz",
-      "integrity": "sha512-mZ1MSKhZBYoV8GAWceA+PEJFWV2VpdNSpxxcj1wjIAOi00ykRuIQChT99xlQGZWLY3/NApWhSImlFwsmCEs4vA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.7.3.tgz",
+      "integrity": "sha512-kleJ1iUTxcO32Y06dH9Pfi9K4U+Tlb111WXEnbt7R/ne+NLRwppZiTGJuTD5VVoxTMK5NTbEtm5t2vcdNCFe2g==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.4.0",
@@ -46,50 +46,38 @@
       }
     },
     "@azure/core-lro": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.2.4.tgz",
-      "integrity": "sha512-e1I2v2CZM0mQo8+RSix0x091Av493e4bnT22ds2fcQGslTHzM2oTbswkB65nP4iEpCxBrFxOSDPKExmTmjCVtQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.5.3.tgz",
+      "integrity": "sha512-ubkOf2YCnVtq7KqEJQqAI8dDD5rH1M6OP5kW0KO/JQyTaxLA0N0pjFWvvaysCj9eHMNBcuuoZXhhl0ypjod2DA==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/core-util": "^1.2.0",
         "@azure/logger": "^1.0.0",
         "tslib": "^2.2.0"
-      },
-      "dependencies": {
-        "@azure/core-tracing": {
-          "version": "1.0.0-preview.13",
-          "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
-          "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
-          "requires": {
-            "@opentelemetry/api": "^1.0.1",
-            "tslib": "^2.2.0"
-          }
-        }
       }
     },
     "@azure/core-paging": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.3.0.tgz",
-      "integrity": "sha512-H6Tg9eBm0brHqLy0OSAGzxIh1t4UL8eZVrSUMJ60Ra9cwq2pOskFqVpz2pYoHDsBY1jZ4V/P8LRGb5D5pmC6rg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.5.0.tgz",
+      "integrity": "sha512-zqWdVIt+2Z+3wqxEOGzR5hXFZ8MGKK52x4vFLw8n58pR6ZfKRx3EXYTxTaYxYHc/PexPUTyimcTWFJbji9Z6Iw==",
       "requires": {
         "tslib": "^2.2.0"
       }
     },
     "@azure/core-rest-pipeline": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.9.1.tgz",
-      "integrity": "sha512-OVtt0LP0K5ktsKTmh6/695P0mPFmngjdCJPr4V0uvrkhHTkARSQ3VYRnxRc0LC9g3mHcH90C+8a6iF7ApMAZKg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.11.0.tgz",
+      "integrity": "sha512-nB4KXl6qAyJmBVLWA7SakT4tzpYZTCk4pvRBeI+Ye0WYSOrlTqlMhc4MSS/8atD3ufeYWdkN380LLoXlUUzThw==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-util": "^1.3.0",
         "@azure/logger": "^1.0.0",
         "form-data": "^4.0.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
+        "tslib": "^2.2.0"
       }
     },
     "@azure/core-tracing": {
@@ -101,10 +89,11 @@
       }
     },
     "@azure/core-util": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.0.0.tgz",
-      "integrity": "sha512-yWshY9cdPthlebnb3Zuz/j0Lv4kjU6u7PR5sW7A9FF7EX+0irMRJAtyTq5TPiDHJfjH8gTSlnIYFj9m7Ed76IQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.3.2.tgz",
+      "integrity": "sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==",
       "requires": {
+        "@azure/abort-controller": "^1.0.0",
         "tslib": "^2.2.0"
       }
     },
@@ -132,9 +121,9 @@
       }
     },
     "@azure/keyvault-keys": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.7.0.tgz",
-      "integrity": "sha512-HScWdORbRCKi1vdKI6EChe/t/P/zV7jcGZWfj18BOyeensk5d1/Ynfx1t6xfAy5zUIQvAWVU97hXdCznDpULbQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.7.1.tgz",
+      "integrity": "sha512-zfmlZQCw1Yz+aPhgZmWOYBUzaKmfBzR2yceAE4S6hKDl7YZraTguuXmtFbCqjRvpz+pIMKAK25fENay9mFy1hQ==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
@@ -150,68 +139,47 @@
       }
     },
     "@azure/logger": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
-      "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.4.tgz",
+      "integrity": "sha512-ustrPY8MryhloQj7OWGe+HrYx+aoiOxzbXTtgblbV3xwCqpzUK36phH3XNHQKj3EPonyFUuDTfR3qFhTEAuZEg==",
       "requires": {
         "tslib": "^2.2.0"
       }
     },
     "@azure/msal-browser": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.28.1.tgz",
-      "integrity": "sha512-5uAfwpNGBSRzBGTSS+5l4Zw6msPV7bEmq99n0U3n/N++iTcha+nIp1QujxTPuOLHmTNCeySdMx9qzGqWuy22zQ==",
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.38.0.tgz",
+      "integrity": "sha512-gxBh83IumHgEP9uMCm9pJLKLRwICMQTxG9TX3AytdNt3oLUI3tytm/szYD5u5zKJgSkhHvwFSM+NPnM04hYw3w==",
       "requires": {
-        "@azure/msal-common": "^7.3.0"
+        "@azure/msal-common": "13.2.0"
+      },
+      "dependencies": {
+        "@azure/msal-common": {
+          "version": "13.2.0",
+          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.2.0.tgz",
+          "integrity": "sha512-rnstQ7Zgn3fSTKNQO+/YNV34/QXJs0vni7IA0/3QB1EEyrJg14xyRmTqlw9ta+pdSuT5OJwUP8kI3D/rBwUIBw=="
+        }
       }
     },
     "@azure/msal-common": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-7.3.0.tgz",
-      "integrity": "sha512-revxB3z+QLjwAtU1d04nC1voFr+i3LfqTpUfgrWZVqKh/sSgg0mZZUvw4vKVWB57qtL95sul06G+TfdFZny1Xw=="
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-7.6.0.tgz",
+      "integrity": "sha512-XqfbglUTVLdkHQ8F9UQJtKseRr3sSnr9ysboxtoswvaMVaEfvyLtMoHv9XdKUfOc0qKGzNgRFd9yRjIWVepl6Q=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.18.0.tgz",
+      "integrity": "sha512-N6GX1Twxw524e7gaJvj7hKtrPRmZl9qGY7U4pmUdx4XzoWYRFfYk4H1ZjVhQ7pwb5Ks88NNhbXVCagsuYPTEFg==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
+        "@azure/msal-common": "13.2.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "dependencies": {
         "@azure/msal-common": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.0.2.tgz",
-          "integrity": "sha512-qzwxuF8kZAp+rNUactMCgJh8fblq9D4lSqrrIxMDzLjgSZtjN32ix7r/HBe8QdOr76II9SVVPcMkX4sPzPfQ7w=="
-        },
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "jws": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-          "requires": {
-            "jwa": "^1.4.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "13.2.0",
+          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.2.0.tgz",
+          "integrity": "sha512-rnstQ7Zgn3fSTKNQO+/YNV34/QXJs0vni7IA0/3QB1EEyrJg14xyRmTqlw9ta+pdSuT5OJwUP8kI3D/rBwUIBw=="
         }
       }
     },
@@ -278,9 +246,9 @@
       "dev": true
     },
     "@js-joda/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-0OriPYIaMLB3XiLQMe0BXKVIqeriTn3H7JMOzTsHEtt7Zqq+TetCu97KnAhU3ckiQZKBxfZshft+H1OC4D1lXw=="
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.5.3.tgz",
+      "integrity": "sha512-7dqNYwG8gCt4hfg5PKgM7xLEcgSBcx/UgC92OMnhMmvAnq11QzDFPrxUkNR/u5kn17WWLZ8beZ4A3Qrz4pZcmQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -308,11 +276,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@opentelemetry/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
-    },
     "@tediousjs/connection-string": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tediousjs/connection-string/-/connection-string-0.4.1.tgz",
@@ -323,24 +286,11 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
     },
-    "@types/es-aggregate-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/es-aggregate-error/-/es-aggregate-error-1.0.2.tgz",
-      "integrity": "sha512-erqUpFXksaeR2kejKnhnjZjbFxUpGZx4Z7ydNL9ie8tEhXPiZTsLeUDJ6aR1F8j5wWUAtOAQWUqkc7givBJbBA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
-    },
-    "@types/node": {
-      "version": "18.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -416,6 +366,15 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      }
     },
     "array-includes": {
       "version": "3.1.5",
@@ -785,7 +744,12 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -805,9 +769,9 @@
       "dev": true
     },
     "bl": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-      "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
       "requires": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -851,7 +815,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "builtins": {
       "version": "5.0.1",
@@ -1023,7 +987,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "diff": {
       "version": "5.0.0",
@@ -1100,56 +1064,78 @@
       }
     },
     "es-aggregate-error": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.8.tgz",
-      "integrity": "sha512-AKUb5MKLWMozPlFRHOKqWD7yta5uaEhH21qwtnf6FlKjNjTJOoqFi0/G14+FfSkIQhhu6X68Af4xgRC6y8qG4A==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.9.tgz",
+      "integrity": "sha512-fvnX40sb538wdU6r4s35cq4EY6Lr09Upj40BEVem4LEsuW8XgQep9yD5Q1U2KftokNp1rWODFJ2qwZSsAjFpbg==",
       "requires": {
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
+        "es-abstract": "^1.20.4",
         "function-bind": "^1.1.1",
         "functions-have-names": "^1.2.3",
-        "get-intrinsic": "^1.1.1",
-        "globalthis": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "globalthis": "^1.0.3",
         "has-property-descriptors": "^1.0.0"
       },
       "dependencies": {
         "define-properties": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+          "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
           "requires": {
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
           }
         },
         "es-abstract": {
-          "version": "1.20.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-          "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+          "version": "1.21.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+          "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
           "requires": {
+            "array-buffer-byte-length": "^1.0.0",
+            "available-typed-arrays": "^1.0.5",
             "call-bind": "^1.0.2",
+            "es-set-tostringtag": "^2.0.1",
             "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
             "function.prototype.name": "^1.1.5",
-            "get-intrinsic": "^1.1.1",
+            "get-intrinsic": "^1.2.0",
             "get-symbol-description": "^1.0.0",
+            "globalthis": "^1.0.3",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
+            "has-proto": "^1.0.1",
             "has-symbols": "^1.0.3",
-            "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.4",
+            "internal-slot": "^1.0.5",
+            "is-array-buffer": "^3.0.2",
+            "is-callable": "^1.2.7",
             "is-negative-zero": "^2.0.2",
             "is-regex": "^1.1.4",
             "is-shared-array-buffer": "^1.0.2",
             "is-string": "^1.0.7",
+            "is-typed-array": "^1.1.10",
             "is-weakref": "^1.0.2",
-            "object-inspect": "^1.12.0",
+            "object-inspect": "^1.12.3",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.2",
+            "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
-            "unbox-primitive": "^1.0.2"
+            "safe-regex-test": "^1.0.0",
+            "string.prototype.trim": "^1.2.7",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
+            "typed-array-length": "^1.0.4",
+            "unbox-primitive": "^1.0.2",
+            "which-typed-array": "^1.1.9"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3"
           }
         },
         "has-bigints": {
@@ -1162,6 +1148,21 @@
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         },
+        "internal-slot": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+          "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+          "requires": {
+            "get-intrinsic": "^1.2.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+          "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+        },
         "is-shared-array-buffer": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -1170,24 +1171,40 @@
             "call-bind": "^1.0.2"
           }
         },
-        "string.prototype.trimend": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-          "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+        "object-inspect": {
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+        },
+        "object.assign": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+          "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.4",
-            "es-abstract": "^1.19.5"
+            "has-symbols": "^1.0.3",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+          "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.20.4"
           }
         },
         "string.prototype.trimstart": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-          "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+          "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.4",
-            "es-abstract": "^1.19.5"
+            "es-abstract": "^1.20.4"
           }
         },
         "unbox-primitive": {
@@ -1200,6 +1217,34 @@
             "has-symbols": "^1.0.3",
             "which-boxed-primitive": "^1.0.2"
           }
+        }
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         }
       }
     },
@@ -1751,6 +1796,14 @@
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -1897,6 +1950,32 @@
         "slash": "^3.0.0"
       }
     },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -1935,6 +2014,11 @@
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -2032,6 +2116,34 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        }
       }
     },
     "is-arrayish": {
@@ -2169,6 +2281,18 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -2247,6 +2371,28 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonwebtoken": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "integrity": "sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        }
       }
     },
     "jsx-ast-utils": {
@@ -2492,7 +2638,7 @@
     "native-duplexpair": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
-      "integrity": "sha1-eJkHjmS/PIo9cyYBs9QP8F21j6A="
+      "integrity": "sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -2501,9 +2647,9 @@
       "dev": true
     },
     "node-abort-controller": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
-      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -2689,9 +2835,9 @@
       }
     },
     "open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "requires": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -2902,9 +3048,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2993,10 +3139,46 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        }
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -3111,6 +3293,159 @@
         }
       }
     },
+    "string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+          "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.21.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+          "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
+          "requires": {
+            "array-buffer-byte-length": "^1.0.0",
+            "available-typed-arrays": "^1.0.5",
+            "call-bind": "^1.0.2",
+            "es-set-tostringtag": "^2.0.1",
+            "es-to-primitive": "^1.2.1",
+            "function.prototype.name": "^1.1.5",
+            "get-intrinsic": "^1.2.0",
+            "get-symbol-description": "^1.0.0",
+            "globalthis": "^1.0.3",
+            "gopd": "^1.0.1",
+            "has": "^1.0.3",
+            "has-property-descriptors": "^1.0.0",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3",
+            "internal-slot": "^1.0.5",
+            "is-array-buffer": "^3.0.2",
+            "is-callable": "^1.2.7",
+            "is-negative-zero": "^2.0.2",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.2",
+            "is-string": "^1.0.7",
+            "is-typed-array": "^1.1.10",
+            "is-weakref": "^1.0.2",
+            "object-inspect": "^1.12.3",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.4",
+            "regexp.prototype.flags": "^1.4.3",
+            "safe-regex-test": "^1.0.0",
+            "string.prototype.trim": "^1.2.7",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
+            "typed-array-length": "^1.0.4",
+            "unbox-primitive": "^1.0.2",
+            "which-typed-array": "^1.1.9"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-bigints": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        },
+        "internal-slot": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+          "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+          "requires": {
+            "get-intrinsic": "^1.2.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+          "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+        },
+        "is-shared-array-buffer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+          "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+        },
+        "object.assign": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+          "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "has-symbols": "^1.0.3",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+          "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.20.4"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+          "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.20.4"
+          }
+        },
+        "unbox-primitive": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+          "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.0.3",
+            "which-boxed-primitive": "^1.0.2"
+          }
+        }
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
@@ -3179,21 +3514,20 @@
       "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ=="
     },
     "tedious": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-15.0.1.tgz",
-      "integrity": "sha512-9zmeSUxNoenjO6E/Q9ySoqGU2RWx1rU/FOIgwjvGHXBf06vGybD8S4gAJDBG0qcTsHTZQ1TC4p16m6fGF72O+Q==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-16.1.0.tgz",
+      "integrity": "sha512-5W+shTkUoAyrB/Bbx89k6Q8Cb400OHzS6XDXQdsTp/obe1cFyOhNc1KI4FI6TOzklDGJWyLnEEfUSBVMpugnjA==",
       "requires": {
         "@azure/identity": "^2.0.4",
         "@azure/keyvault-keys": "^4.4.0",
         "@js-joda/core": "^5.2.0",
-        "@types/es-aggregate-error": "^1.0.2",
         "bl": "^5.0.0",
         "es-aggregate-error": "^1.0.8",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.0.1",
+        "node-abort-controller": "^3.1.1",
         "punycode": "^2.1.0",
         "sprintf-js": "^1.1.2"
       }
@@ -3226,9 +3560,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -3244,6 +3578,16 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
+    },
+    "typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      }
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -3268,7 +3612,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
       "version": "8.3.2",
@@ -3300,6 +3644,19 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug": "^4.3.3",
     "rfdc": "^1.3.0",
     "tarn": "^3.0.2",
-    "tedious": "^15.0.1"
+    "tedious": "^16.1.0"
   },
   "devDependencies": {
     "mocha": "^10.0.0",


### PR DESCRIPTION
Updates tedious to v16.1.0. The only [documented breaking change](https://github.com/tediousjs/tedious/releases/tag/v16.0.0) from v15 -> v16 is dropping support to node14.