### PR TITLE
chore(ci): keep release jobs in a single concurrency group

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -191,6 +191,7 @@ jobs:
         run: npm run test-msnodesqlv8
   release:
     name: Release
+    concurrency: release
     if: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
This aims to keep the release job to a single concurrency model to make sure that there aren't any race conditions when performing a release.
