### PR TITLE
ci: do not run release steps on forks

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -192,7 +192,7 @@ jobs:
   release:
     name: Release
     concurrency: release
-    if: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.repository_owner == 'tediousjs' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     needs:
       - commitlint


### PR DESCRIPTION
What this does:

Removes the release step on forks

Related issues:

<!-- Provide links to any related issues or issues being closed by this PR -->

Pre/Post merge checklist:

- [ ] Update change log
