### PR TITLE
ci: update dependabot to use groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,15 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      release-tools:
+        patterns:
+          - "@commitlint/*"
+          - "semantic-release"
+          - "@semantic-release/*"
+      test-tools:
+        patterns:
+          - "mocha"
+      lint-tools:
+        patterns:
+          - "standard"


### PR DESCRIPTION
What this does:

Update the dependabot config to use the new [groups feature](https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/)

Related issues:

<!-- Provide links to any related issues or issues being closed by this PR -->

Pre/Post merge checklist:

- [ ] Update change log
