### PR TITLE
chore(package): bump min node version from 10 to 14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "standard": "^17.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "standard": "^17.0.0"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
What this does:

Bumps the minimum support node version from 10 to 14

Related issues:

Support was dropped elsewhere as part of #1547 

Pre/Post merge checklist:

- [ ] Update change log
