### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/bin/mssql
+++ b/bin/mssql
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 const { Command } = require('commander')
 const { version } = require('../package.json')
-const { resolve: resolvePath } = require('path')
-const { constants: { R_OK } } = require('fs')
+const { resolve: resolvePath } = require('node:path')
+const { constants: { R_OK } } = require('node:fs')
 const { ConnectionPool } = require('../')
-const { lstat, access, readFile } = require('fs').promises
+const { lstat, access, readFile } = require('node:fs/promises')
 Buffer.prototype.toJSON = () => {
   return `0x${this.toString('hex')}`
 }

--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { EventEmitter } = require('events')
+const { EventEmitter } = require('node:events')
 const debug = require('debug')('mssql:base')
 const { parseSqlConnectionString } = require('@tediousjs/connection-string')
 const tarn = require('tarn')

--- a/lib/base/prepared-statement.js
+++ b/lib/base/prepared-statement.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const debug = require('debug')('mssql:base')
-const { EventEmitter } = require('events')
+const { EventEmitter } = require('node:events')
 const { IDS, objectHasProperty } = require('../utils')
 const globalConnection = require('../global-connection')
 const { TransactionError, PreparedStatementError } = require('../error')

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const debug = require('debug')('mssql:base')
-const { EventEmitter } = require('events')
-const { Readable } = require('stream')
+const { EventEmitter } = require('node:events')
+const { Readable } = require('node:stream')
 const { IDS, objectHasProperty } = require('../utils')
 const globalConnection = require('../global-connection')
 const { RequestError, ConnectionError } = require('../error')

--- a/lib/base/transaction.js
+++ b/lib/base/transaction.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const debug = require('debug')('mssql:base')
-const { EventEmitter } = require('events')
+const { EventEmitter } = require('node:events')
 const { IDS } = require('../utils')
 const globalConnection = require('../global-connection')
 const { TransactionError } = require('../error')

--- a/lib/msnodesqlv8/connection-pool.js
+++ b/lib/msnodesqlv8/connection-pool.js
@@ -6,7 +6,7 @@ const BaseConnectionPool = require('../base/connection-pool')
 const { IDS, INCREMENT } = require('../utils')
 const shared = require('../shared')
 const ConnectionError = require('../error/connection-error')
-const { platform } = require('os')
+const { platform } = require('node:os')
 const { buildConnectionString } = require('@tediousjs/connection-string')
 
 const CONNECTION_DRIVER = ['darwin', 'linux'].includes(platform()) ? 'ODBC Driver 17 for SQL Server' : 'SQL Server Native Client 11.0'

--- a/test/common/cli.js
+++ b/test/common/cli.js
@@ -2,12 +2,12 @@
 
 /* globals describe, it */
 
-const assert = require('assert')
-const { join } = require('path')
+const assert = require('node:assert')
+const { join } = require('node:path')
 const { spawn } = require('child_process')
 
 const config = function () {
-  const cfg = JSON.parse(require('fs').readFileSync(join(__dirname, '../.mssql.json')))
+  const cfg = JSON.parse(require('node:fs').readFileSync(join(__dirname, '../.mssql.json')))
   cfg.driver = 'tedious'
   return cfg
 }

--- a/test/common/templatestring.js
+++ b/test/common/templatestring.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const assert = require('assert')
+const assert = require('node:assert')
 
 module.exports = (sql, driver) => {
   return {

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const assert = require('assert')
-const stream = require('stream')
-const { join } = require('path')
-const { format } = require('util')
+const assert = require('node:assert')
+const stream = require('node:stream')
+const { join } = require('node:path')
+const { format } = require('node:util')
 const ISOLATION_LEVELS = require('../../lib/isolationlevel')
 const BaseTransaction = require('../../lib/base/transaction')
 const versionHelper = require('./versionhelper')

--- a/test/common/times.js
+++ b/test/common/times.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const assert = require('assert')
+const assert = require('node:assert')
 
 module.exports = (sql, driver) => {
   return {

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -3,7 +3,7 @@
 /* globals describe, it, afterEach */
 
 const sql = require('../../')
-const assert = require('assert')
+const assert = require('node:assert')
 const udt = require('../../lib/udt')
 const BasePool = require('../../lib/base/connection-pool')
 const ConnectionPool = require('../../lib/tedious/connection-pool')

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -2,7 +2,7 @@
 
 /* globals describe, it, before, after, afterEach */
 
-const { join } = require('path')
+const { join } = require('node:path')
 const sql = require('../../msnodesqlv8')
 
 const TESTS = require('../common/tests.js')(sql, 'msnodesqlv8')
@@ -10,7 +10,7 @@ const TIMES = require('../common/times.js')(sql, 'msnodesqlv8')
 const versionHelper = require('../common/versionhelper')
 
 const config = function () {
-  const cfg = JSON.parse(require('fs').readFileSync(join(__dirname, '../.mssql.json')))
+  const cfg = JSON.parse(require('node:fs').readFileSync(join(__dirname, '../.mssql.json')))
   cfg.driver = 'msnodesqlv8'
   return cfg
 }
@@ -24,11 +24,11 @@ describe('msnodesqlv8', function () {
       if (err) return done(err)
 
       let req = new sql.Request()
-      req.batch(require('fs').readFileSync(join(__dirname, '../cleanup.sql'), 'utf8'), function (err) {
+      req.batch(require('node:fs').readFileSync(join(__dirname, '../cleanup.sql'), 'utf8'), function (err) {
         if (err) return done(err)
 
         req = new sql.Request()
-        req.batch(require('fs').readFileSync(join(__dirname, '../prepare.sql'), 'utf8'), function (err) {
+        req.batch(require('node:fs').readFileSync(join(__dirname, '../prepare.sql'), 'utf8'), function (err) {
           if (err) return done(err)
 
           sql.close(done)
@@ -245,7 +245,7 @@ describe('msnodesqlv8', function () {
       if (err) return done(err)
 
       const req = new sql.Request()
-      req.query(require('fs').readFileSync(join(__dirname, '../cleanup.sql'), 'utf8'), function (err) {
+      req.query(require('node:fs').readFileSync(join(__dirname, '../cleanup.sql'), 'utf8'), function (err) {
         if (err) return done(err)
 
         sql.close(done)

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -3,8 +3,8 @@
 /* globals describe, it, before, after, afterEach */
 
 const sql = require('../../tedious.js')
-const assert = require('assert')
-const { join } = require('path')
+const assert = require('node:assert')
+const { join } = require('node:path')
 
 const TESTS = require('../common/tests.js')(sql, 'tedious')
 const TIMES = require('../common/times.js')(sql, 'tedious')
@@ -16,7 +16,7 @@ if (parseInt(process.version.match(/^v(\d+)\./)[1]) > 0) {
 }
 
 const config = function () {
-  const cfg = JSON.parse(require('fs').readFileSync(join(__dirname, '../.mssql.json')))
+  const cfg = JSON.parse(require('node:fs').readFileSync(join(__dirname, '../.mssql.json')))
   cfg.driver = 'tedious'
   return cfg
 }
@@ -30,11 +30,11 @@ describe('tedious', () => {
       if (err) return done(err)
 
       let req = new sql.Request()
-      req.query(require('fs').readFileSync(join(__dirname, '../cleanup.sql'), 'utf8'), err => {
+      req.query(require('node:fs').readFileSync(join(__dirname, '../cleanup.sql'), 'utf8'), err => {
         if (err) return done(err)
 
         req = new sql.Request()
-        req.query(require('fs').readFileSync(join(__dirname, '../prepare.sql'), 'utf8'), err => {
+        req.query(require('node:fs').readFileSync(join(__dirname, '../prepare.sql'), 'utf8'), err => {
           if (err) return done(err)
 
           sql.close(done)
@@ -345,7 +345,7 @@ describe('tedious', () => {
       if (err) return done(err)
 
       const req = new sql.Request()
-      req.query(require('fs').readFileSync(join(__dirname, '../cleanup.sql'), 'utf8'), function (err) {
+      req.query(require('node:fs').readFileSync(join(__dirname, '../cleanup.sql'), 'utf8'), function (err) {
         if (err) return done(err)
 
         sql.close(done)


### PR DESCRIPTION
What this does:

Allows redundant `require.cache` calls to be bypassed for builtin modules, saving a few yoctoseconds.

See https://nodejs.org/api/modules.html#core-modules and [discussion in nodejs/node repo regarding why `require.cache` calls are redundant for builtins](https://github.com/nodejs/node/pull/37246/files#r588397158).

Related issues:

N/A

Pre/Post merge checklist:

- [ ] Update change log
