### PR TITLE
perf: remove unused regex capture groups

### DIFF
--- a/lib/base/prepared-statement.js
+++ b/lib/base/prepared-statement.js
@@ -91,7 +91,7 @@ class PreparedStatement extends EventEmitter {
    */
 
   input (name, type) {
-    if ((/(--| |\/\*|\*\/|')/).test(name)) {
+    if (/(--| |\/\*|\*\/|')/.test(name)) {
       throw new PreparedStatementError(`SQL injection warning for param '${name}'`, 'EINJECT')
     }
 

--- a/lib/base/prepared-statement.js
+++ b/lib/base/prepared-statement.js
@@ -91,7 +91,7 @@ class PreparedStatement extends EventEmitter {
    */
 
   input (name, type) {
-    if (/(--| |\/\*|\*\/|')/.test(name)) {
+    if (/--| |\/\*|\*\/|'/.test(name)) {
       throw new PreparedStatementError(`SQL injection warning for param '${name}'`, 'EINJECT')
     }
 
@@ -144,7 +144,7 @@ class PreparedStatement extends EventEmitter {
    */
 
   output (name, type) {
-    if (/(--| |\/\*|\*\/|')/.test(name)) {
+    if (/--| |\/\*|\*\/|'/.test(name)) {
       throw new PreparedStatementError(`SQL injection warning for param '${name}'`, 'EINJECT')
     }
 

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -107,7 +107,7 @@ class Request extends EventEmitter {
    */
 
   input (name, type, value) {
-    if ((/(--| |\/\*|\*\/|')/).test(name)) {
+    if (/(--| |\/\*|\*\/|')/.test(name)) {
       throw new RequestError(`SQL injection warning for param '${name}'`, 'EINJECT')
     }
 
@@ -170,7 +170,7 @@ class Request extends EventEmitter {
   output (name, type, value) {
     if (!type) { type = TYPES.NVarChar }
 
-    if ((/(--| |\/\*|\*\/|')/).test(name)) {
+    if (/(--| |\/\*|\*\/|')/.test(name)) {
       throw new RequestError(`SQL injection warning for param '${name}'`, 'EINJECT')
     }
 

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -107,7 +107,7 @@ class Request extends EventEmitter {
    */
 
   input (name, type, value) {
-    if (/(--| |\/\*|\*\/|')/.test(name)) {
+    if (/--| |\/\*|\*\/|'/.test(name)) {
       throw new RequestError(`SQL injection warning for param '${name}'`, 'EINJECT')
     }
 
@@ -170,7 +170,7 @@ class Request extends EventEmitter {
   output (name, type, value) {
     if (!type) { type = TYPES.NVarChar }
 
-    if (/(--| |\/\*|\*\/|')/.test(name)) {
+    if (/--| |\/\*|\*\/|'/.test(name)) {
       throw new RequestError(`SQL injection warning for param '${name}'`, 'EINJECT')
     }
 


### PR DESCRIPTION
What this does:

Removes unused capture groups `(` `)` inside regex.
A capture group is intended to store its matched text so it can be used later on e.g. in text replacements, so the regex engine has to do extra work every time a capture group is matched compared to a non-capture group.
The captured text is never used elsewhere here.

Related issues:

N/A

Pre/Post merge checklist:

- [ ] Update change log
