### PR TITLE
chore(package): explicitly declare js module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "version": "9.1.1",
   "main": "index.js",
+  "type": "commonjs",
   "repository": "github:tediousjs/node-mssql",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
What this does:

[Node 21.1.0 added a flag to detect module types](https://github.com/nodejs/node/releases/tag/v21.1.0), which will probably become default in the future. Declaring the type will cause Node to skip detection on startup/compile, reducing startup time.

Declaring the package type is also considered good practice according to https://nodejs.org/api/modules.html#enabling.

Related issues:

N/A

Pre/Post merge checklist:

- [ ] Update change log
