### PR TITLE
_acquire in case of reject return a promise, if this._acquire.promise is used in acquire, in case of reject an exception is raised that is not "captured" by the catch

### DIFF
--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -363,7 +363,7 @@ class ConnectionPool extends EventEmitter {
    */
 
   acquire (requester, callback) {
-    const acquirePromise = shared.Promise.resolve(this._acquire().promise).catch(err => {
+    const acquirePromise = shared.Promise.resolve(this._acquire()).catch(err => {
       this.emit('error', err)
       throw err
     })
@@ -382,7 +382,7 @@ class ConnectionPool extends EventEmitter {
       return shared.Promise.reject(new ConnectionError('Connection is closing', 'ENOTOPEN'))
     }
 
-    return this.pool.acquire()
+    return this.pool.acquire().promise
   }
 
   /**


### PR DESCRIPTION
What this does:

In case of reject acquire raise an exception that is controlled by catch : in previous version the raised exception was not captured from catch and if this node is used inside node-red-contrib-mssql-plus that run on node-red the result is an uncaught exception that stop it.

Related issues:

See this link https://github.com/bestlong/node-red-contrib-mssql-plus/issues/88#issuecomment-1840435259

Pre/Post merge checklist:

- [ ] Update change log
