### PR TITLE
Support passing multiSubnetFailover option to tedious driver

### DIFF
--- a/lib/tedious/connection-pool.js
+++ b/lib/tedious/connection-pool.js
@@ -45,6 +45,7 @@ class ConnectionPool extends BaseConnectionPool {
     cfg.options.rowCollectionOnRequestCompletion = cfg.options.rowCollectionOnRequestCompletion || false
     cfg.options.useColumnNames = cfg.options.useColumnNames || false
     cfg.options.appName = cfg.options.appName || 'node-mssql'
+    cfg.options.multiSubnetFailover = this.config.multiSubnetFailover || false;
 
     // tedious always connect via tcp when port is specified
     if (cfg.options.instanceName) delete cfg.options.port


### PR DESCRIPTION
What this does:

This PR allow option `multiSubnetFailover` to be passed from typeorm -> node-mssql -> tedious driver.

This option allow support for MSSQL alway on avalibility group that primary site and secondary site using IP in difference subnet.
![image](https://github.com/tediousjs/node-mssql/assets/803047/729c4c60-9e61-47f2-b35a-4d34fdb15546)
ref: https://learn.microsoft.com/en-us/sql/sql-server/failover-clusters/windows/sql-server-multi-subnet-clustering-sql-server?view=sql-server-ver16#DNS
in tediousjs this feature was implemented in https://github.com/tediousjs/tedious/pull/362

with current version of TypeORM (0.3.20), multiSubnetFailover option can be passed in extra section as below.
```
export const AppDataSource = new DataSource({
    type: "mssql",
    host: "127.0.0.1",
    username: "sa",
    password: "somepassword",
    database: "tempdb",
    synchronize: true,
    logging: false,
    entities: [User],
    migrations: [],
    subscribers: [],
    options: {
        trustServerCertificate: true,  
    },
    extra: {
        multiSubnetFailover: true,
    }
})
```
however, without this PR. TypeORM pass multiSubnetFailover config option to Node-MSSQL, however Node-MSSQL will never be passed this option to TediousJS.

Related issues:

https://github.com/tediousjs/node-mssql/issues/1619

Pre/Post merge checklist:

- [ ] Update change log
