### PR TITLE
ci: use conventionalcommits release preset

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,3 +1,4 @@
+preset: 'conventionalcommits'
 plugins:
   - '@semantic-release/commit-analyzer'
   - '@semantic-release/release-notes-generator'


### PR DESCRIPTION
What this does:

This should allow us to use the `feat!` commit prefix for breaking changes.