### PR TITLE
fix: TypeError with BigInt param

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -57,7 +57,6 @@ const getTypeByValue = function (value) {
       return TYPES.NVarChar
 
     case 'number':
-    case 'bigint':
       if (value % 1 === 0) {
         if (value < -2147483648 || value > 2147483647) {
           return TYPES.BigInt
@@ -66,6 +65,13 @@ const getTypeByValue = function (value) {
         }
       } else {
         return TYPES.Float
+      }
+
+    case 'bigint':
+      if (value < -2147483648n || value > 2147483647n) {
+        return TYPES.BigInt
+      } else {
+        return TYPES.Int
       }
 
     case 'boolean':


### PR DESCRIPTION
What this does:

PR fixes a TypeError "Cannot mix BigInt and other types, use explicit conversions" when passing a bigint parameter to request

The following example crashed with error:
```javascript
const request = new mssql.Request();
request.input('bigintpara', BigInt('4294967294'));
```
Now it does not raise an error.