### PR TITLE
test: make sure bigint intputs do not throw

### DIFF
--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -162,6 +162,11 @@ module.exports = (sql, driver) => {
         done()
       }).catch(done)
     },
+    'bigint inputs' (done) {
+      const req = new TestRequest()
+      req.input('bigintparam', BigInt('4294967294'))
+      done()
+    },
     'stored procedure' (mode, done) {
       const req = new TestRequest()
       req.input('in', sql.Int, null)

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -46,6 +46,7 @@ describe('msnodesqlv8', function () {
 
     it('config validation', done => TESTS['config validation'](done))
     it('value handler', done => TESTS['value handler'](done))
+    it('bigint inputs', done => TESTS['bigint inputs'](done))
     it('stored procedure (exec)', done => TESTS['stored procedure']('execute', done))
     it('stored procedure (batch)', done => TESTS['stored procedure']('batch', done))
     it('user defined types', done => TESTS['user defined types'](done))

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -53,6 +53,7 @@ describe('tedious', () => {
 
     it('config validation', done => TESTS['config validation'](done))
     it('value handler', done => TESTS['value handler'](done))
+    it('bigint inputs', done => TESTS['bigint inputs'](done))
     it('stored procedure (exec)', done => TESTS['stored procedure']('execute', done))
     it('stored procedure (batch)', done => TESTS['stored procedure']('batch', done))
     it('user defined types', done => TESTS['user defined types'](done))


### PR DESCRIPTION
What this does:

bigint params may throw when compared to ints

Related issues:

#1677 

Pre/Post merge checklist:

- [ ] Update change log
