### PR TITLE
Refactor parseFigures function to simplify property checks and improve readability

### DIFF
--- a/lib/udt.js
+++ b/lib/udt.js
@@ -128,18 +128,13 @@ const parseFigures = (buffer, count, properties) => {
     return figures
   }
 
-  if (properties.P) {
-    figures.push({
-      attribute: 0x01,
-      pointOffset: 0
-    })
-  } else if (properties.L) {
+  if (properties.P || properties.L) {
     figures.push({
       attribute: 0x01,
       pointOffset: 0
     })
   } else {
-    for (let i = 1; i <= count; i++) {
+    for (let i = 0; i < count; i++) {
       figures.push({
         attribute: buffer.readUInt8(buffer.position),
         pointOffset: buffer.readInt32LE(buffer.position + 1)


### PR DESCRIPTION
Refactor parseFigures function to simplify property checks and improve readability

- Combined redundant checks for 'properties.P' and 'properties.L' into a single condition
- Removed unnecessary loop index starting from 1, now loops from 0