### PR TITLE
Refactor parseShapes function to simplify property checks and improve readability

### DIFF
--- a/lib/udt.js
+++ b/lib/udt.js
@@ -160,20 +160,14 @@ const parseShapes = (buffer, count, properties) => {
     return shapes
   }
 
-  if (properties.P) {
+  if (properties.P || properties.L) {
     shapes.push({
       parentOffset: -1,
       figureOffset: 0,
-      type: 0x01
-    })
-  } else if (properties.L) {
-    shapes.push({
-      parentOffset: -1,
-      figureOffset: 0,
-      type: 0x02
+      type: properties.P ? 0x01 : 0x02
     })
   } else {
-    for (let i = 1; i <= count; i++) {
+    for (let i = 0; i < count; i++) {
       shapes.push({
         parentOffset: buffer.readInt32LE(buffer.position),
         figureOffset: buffer.readInt32LE(buffer.position + 4),


### PR DESCRIPTION
Refactor parseShapes function to simplify property checks and improve readability

- Combined checks for properties.P and properties.L into a single conditional statement.
- Replaced separate blocks for properties.P and properties.L with a ternary operator to set the type (0x01 for P, 0x02 for L).
- Updated the loop to start from 0 instead of 1 for consistency and clarity.
- Preserved the logic for reading buffer values and updating the buffer position after each iteration.

These changes streamline the function without altering its core behavior.

