### PR TITLE
chore(package): fix repository url; add homepage and bugs urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,14 @@
   "version": "9.1.1",
   "main": "index.js",
   "type": "commonjs",
-  "repository": "github:tediousjs/node-mssql",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tediousjs/node-mssql.git"
+  },
+  "homepage": "https://github.com/tediousjs/node-mssql#readme",
+  "bugs": {
+    "url": "https://github.com/tediousjs/node-mssql/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "@tediousjs/connection-string": "^0.6.0",
@@ -64,6 +71,6 @@
     "test-cli": "mocha --exit -t 15000 test/common/cli.js"
   },
   "bin": {
-    "mssql": "./bin/mssql"
+    "mssql": "bin/mssql"
   }
 }


### PR DESCRIPTION
What this does:

The repository URL and bin value was fixed by simply running `npm pkg fix`, which is [what `npm publish` does prior to publishing](https://docs.npmjs.com/cli/v10/commands/npm-pkg#description).

The addition of the [`homepage`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#homepage) property allows for the URL to the repo to be correctly displayed when hovered over in VS Code when using a proxy registry like in Azure DevOps:

![image](https://github.com/user-attachments/assets/102d8a9d-2642-47d3-8a43-97c3983bdde9)

Compared to something like eslint-plugin-regexp, which [does have the homepage set](https://github.com/ota-meshi/eslint-plugin-regexp/blob/2d90a1aca863508647115c76a7b0c23b493eb0e0/package.json#L60):

![image](https://github.com/user-attachments/assets/43f6f798-75dc-4d6d-bc00-df886a08a98d)


The [`bugs`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#bugs) property was also added to allow for `npm bugs` to work. 


Related issues:

N/A
Pre/Post merge checklist:

- [ ] Update change log
