### PR TITLE
chore: add missing `'use strict'` directives

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('./lib/tedious')

--- a/lib/datatypes.js
+++ b/lib/datatypes.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const objectHasProperty = require('./utils').objectHasProperty
 const inspect = Symbol.for('nodejs.util.inspect.custom')
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const IDS = new WeakMap()
 const INCREMENT = {
   Connection: 1,

--- a/msnodesqlv8.js
+++ b/msnodesqlv8.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('./lib/msnodesqlv8')

--- a/tedious.js
+++ b/tedious.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('./lib/tedious')


### PR DESCRIPTION
What this does:

This PR adds missing `'use strict'` directives to the cjs files in this repo. Strict mode can improve performance by eliminating some JavaScript features that hinder optimizations. It also helps avoid subtle bugs by enforcing more consistent scoping and variable declarations.

The [MDN article on strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) alludes to it, but the V8 JS engine used by Node will use more optimised execution paths when strict mode is enabled. See [related Stack Overflow discussion](https://stackoverflow.com/questions/38411552/why-use-strict-improves-performance-10x-in-this-example) for an example.

Related issues:

N/A

Pre/Post merge checklist:

- [ ] Update change log
