### PR TITLE
style(lib/shared): destructure datatypes import

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const  { TYPES } = require('./datatypes')
+const { TYPES } = require('./datatypes')
 const Table = require('./table')
 
 let PromiseLibrary = Promise

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const TYPES = require('./datatypes').TYPES
+const  { TYPES } = require('./datatypes')
 const Table = require('./table')
 
 let PromiseLibrary = Promise


### PR DESCRIPTION
What this does:

Destructures the datatypes import as it was the last import in the codebase using the old style.

Related issues:

N/A

Pre/Post merge checklist:

- [ ] Update change log
