### PR TITLE
ci: upgrade linux runner to 24.04

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -67,7 +67,7 @@ jobs:
       MSSQL_PASSWORD: 'yourStrong(!)Password'
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         node: [18.x, 20.x, 22.x]
         sqlserver: [2017, 2019, 2022]
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -67,9 +67,16 @@ jobs:
       MSSQL_PASSWORD: 'yourStrong(!)Password'
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-20.04, ubuntu-24.04]
         node: [18.x, 20.x, 22.x]
         sqlserver: [2017, 2019, 2022]
+        exclude:
+          - os: ubuntu-24.04
+            sqlserver: 2017
+          - os: ubuntu-20.04
+            sqlserver: 2019
+          - os: ubuntu-20.04
+            sqlserver: 2022
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
What this does:

The sql-2017 container is crashing on ubuntu 2017; this seems to be a host OS issue because the exact same docker tag used to pass but is now failing. It last passed at the beginning of this month, so some upgrade/change in feb this year has caused the problem.

~The aim to to get the 2017 image running on the 20.04 runner and the rest on 22.04~

The ubuntu 20.04 runner [is being removed](https://github.com/actions/runner-images/issues/11101) from support, so this isn't a long term fix. ~We should try to run on 24.04 instead~. 24.04 has the same issue, but I'll upgrade the runners for the ones that work and downgrade the 2017 runner for now.

---

It seems that the 2017 container won't run on 22.04 nor 24.04, so 20.04 is the only one that can be used for now.

I think the long-term solution will be to stop testing 2017 image on linux :(

Related issues:

<!-- Provide links to any related issues or issues being closed by this PR -->

Pre/Post merge checklist:

- [ ] Update change log
