### PR TITLE
ci(nodejs): add node 24 to test matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   commitlint:
     name: Lint commits
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -34,7 +34,7 @@ jobs:
         run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
   codelint:
     name: Lint code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -162,7 +162,7 @@ jobs:
     name: Release
     concurrency: release
     if: ${{ github.repository_owner == 'tediousjs' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - commitlint
       - codelint

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        node: [18.x, 20.x, 22.x]
+        node: [18.x, 20.x, 22.x, 24.x]
         sqlserver: [2019, 2022]
     steps:
       - name: Checkout code

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -67,16 +67,9 @@ jobs:
       MSSQL_PASSWORD: 'yourStrong(!)Password'
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-24.04]
+        os: [ubuntu-24.04]
         node: [18.x, 20.x, 22.x]
-        sqlserver: [2017, 2019, 2022]
-        exclude:
-          - os: ubuntu-24.04
-            sqlserver: 2017
-          - os: ubuntu-20.04
-            sqlserver: 2019
-          - os: ubuntu-20.04
-            sqlserver: 2022
+        sqlserver: [2019, 2022]
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -153,10 +153,16 @@ jobs:
       - name: Run cli tests
         run: npm run test-cli
       - name: Install msnodesqlv8
-        if: ${{ matrix.node != '22.x' }}
+        if: ${{ matrix.node != '22.x' && matrix.node != '24.x' }}
         run: npm install --no-save msnodesqlv8@^2
       - name: Run msnodesqlv8 tests
-        if: ${{ matrix.node != '22.x' }}
+        if: ${{ matrix.node != '22.x' && matrix.node != '24.x' }}
+        run: npm run test-msnodesqlv8
+      - name: Install msnodesqlv8
+        if: ${{ matrix.node == '22.x' || matrix.node == '24.x' }}
+        run: npm install --no-save msnodesqlv8@^4
+      - name: Run msnodesqlv8 tests
+        if: ${{ matrix.node == '22.x' && matrix.node == '24.x' }}
         run: npm run test-msnodesqlv8
   release:
     name: Release

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, windows-2022]
-        node: [18.x, 20.x, 22.x]
+        node: [18.x, 20.x, 22.x, 24.x]
         sqlserver: [2008, 2012, 2014, 2016, 2017, 2019, 2022]
         # These sqlserver versions don't work on windows-2022 (at the moment)
         exclude:


### PR DESCRIPTION
What this does:

Adds next LTS, Node 24, to test matrix in CI job.

Related issues:

N/A

Pre/Post merge checklist:

- [ ] Update change log
