### PR TITLE
ci: remove sql server 2017 runs from linux test suite

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -67,16 +67,9 @@ jobs:
       MSSQL_PASSWORD: 'yourStrong(!)Password'
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-24.04]
+        os: [ubuntu-24.04]
         node: [18.x, 20.x, 22.x]
-        sqlserver: [2017, 2019, 2022]
-        exclude:
-          - os: ubuntu-24.04
-            sqlserver: 2017
-          - os: ubuntu-20.04
-            sqlserver: 2019
-          - os: ubuntu-20.04
-            sqlserver: 2022
+        sqlserver: [2019, 2022]
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        node: [18.x, 20.x, 22.x]
+        node: [18.x, 20.x, 22.x, 24.x]
         sqlserver: [2019, 2022]
     steps:
       - name: Checkout code
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, windows-2022]
-        node: [18.x, 20.x, 22.x]
+        node: [18.x, 20.x, 22.x, 24.x]
         sqlserver: [2008, 2012, 2014, 2016, 2017, 2019, 2022]
         # These sqlserver versions don't work on windows-2022 (at the moment)
         exclude:


### PR DESCRIPTION
The 2017 test suite only runs on Ubuntu 20.04, but this runner has been removed by GitHub now so the suite cannot be run in GH workflows.

Related issues:

<!-- Provide links to any related issues or issues being closed by this PR -->

Pre/Post merge checklist:

- [ ] Update change log
