### PR TITLE
feat: reset tedious connections when returned to the pool

### DIFF
--- a/lib/tedious/connection-pool.js
+++ b/lib/tedious/connection-pool.js
@@ -149,6 +149,14 @@ class ConnectionPool extends BaseConnectionPool {
       }
     })
   }
+
+  release (connection) {
+    debug('connection(%d): reset', IDS.get(connection))
+    connection.reset(() => {
+      super.release(connection)
+    })
+    return this
+  }
 }
 
 module.exports = ConnectionPool


### PR DESCRIPTION
What this does:

Before a tedious connection is released back to the pool for further use, run `connection.reset()` to clear the connection of any session-specific changes.

fixes #1483 

Related issues:

<!-- Provide links to any related issues or issues being closed by this PR -->

Pre/Post merge checklist:

- [ ] Update change log
