### PR TITLE
ConnectionError now properly displays its message instead of [object …

### DIFF
--- a/lib/error/connection-error.js
+++ b/lib/error/connection-error.js
@@ -18,6 +18,7 @@ class ConnectionError extends MSSQLError {
     super(message, code)
 
     this.name = 'ConnectionError'
+    this.message = message
   }
 }
 

--- a/lib/msnodesqlv8/connection-pool.js
+++ b/lib/msnodesqlv8/connection-pool.js
@@ -23,7 +23,7 @@ class ConnectionPool extends BaseConnectionPool {
 
       if (!this.config.connectionString) {
         cfg.conn_str = buildConnectionString({
-          Driver: CONNECTION_DRIVER,
+          Driver: this.config.connectionDriver || CONNECTION_DRIVER,
           Server: this.config.options.instanceName ? `${this.config.server}\\${this.config.options.instanceName}` : `${this.config.server},${this.config.port}`,
           Database: this.config.database,
           Uid: this.config.user,


### PR DESCRIPTION
…Object], update msnodesqlv8/connection-pool.js - users can pass a connection driver to the connection configuration instead of having predefined values based on user platform.

What this does:

<!-- Describe the PR -->

Related issues:

<!-- Provide links to any related issues or issues being closed by this PR -->

Pre/Post merge checklist:

- [ ] Update change log
