### PR TITLE
feat: remove config object cloning to fix TokenCredential issues

### DIFF
--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -7,7 +7,6 @@ const tarn = require('tarn')
 const { IDS } = require('../utils')
 const ConnectionError = require('../error/connection-error')
 const shared = require('../shared')
-const clone = require('rfdc/default')
 const { MSSQLError } = require('../error')
 
 /**
@@ -53,7 +52,7 @@ class ConnectionPool extends EventEmitter {
         throw ex
       }
     } else {
-      this.config = clone(config)
+      this.config = config
     }
 
     // set defaults

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@tediousjs/connection-string": "^0.6.0",
         "commander": "^11.0.0",
         "debug": "^4.3.3",
-        "rfdc": "^1.3.0",
         "tarn": "^3.0.2",
         "tedious": "^19.0.0"
       },
@@ -9280,11 +9279,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
-    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -17456,11 +17450,6 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
-    },
-    "rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "rimraf": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@tediousjs/connection-string": "^0.6.0",
     "commander": "^11.0.0",
     "debug": "^4.3.3",
-    "rfdc": "^1.3.0",
     "tarn": "^3.0.2",
     "tedious": "^19.0.0"
   },

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -343,17 +343,6 @@ describe('Geography Parsing', () => {
   })
 })
 
-describe('config cloning', () => {
-  it('deeply clones configs', () => {
-    const options = {}
-    const pool = new BasePool({
-      server: 'Instance\\Name',
-      options
-    })
-    assert.notDeepStrictEqual(options, pool.config.options)
-  })
-})
-
 describe('value handlers', () => {
   afterEach('reset valueHandler', () => {
     sql.valueHandler.clear()


### PR DESCRIPTION
What this does:

Config objects are no longer cloned. If a `TokenCredential` was being passed as `config.authentication.options.credential`, it wasn't being handled correctly (see https://github.com/tediousjs/node-mssql/issues/1745#issuecomment-3188319495 for more details)

Related issues:

Fixes #1745

Pre/Post merge checklist:

- [ ] Update change log
