### PR TITLE
ConnectionError now properly displays its message

### DIFF
--- a/lib/error/connection-error.js
+++ b/lib/error/connection-error.js
@@ -18,7 +18,11 @@ class ConnectionError extends MSSQLError {
     super(message, code)
 
     this.name = 'ConnectionError'
-    this.message = message?.details ? JSON.stringify(message.details, null, 2) : message
+
+    let err = message?.details
+    if (err instanceof Array && (err = err.at(-1)?.message)) {
+      this.message = err
+    }
   }
 }
 


### PR DESCRIPTION
supersedes https://github.com/tediousjs/node-mssql/pull/1762

---

without this PR
```
ConnectionError: [object Object]
```

after this PR: example
```
ConnectionError: [
  {
    "sqlState": "28000",
    "message": "[Microsoft][SQL Server Native Client 11.0][SQL Server]Login failed for user 'FakeUser'.",
    "code": 18456
  },
  {
    "sqlState": "42000",
    "message": "[Microsoft][SQL Server Native Client 11.0][SQL Server]Cannot open database \"FakeDatabase\" requested by the login. The login failed.",
    "code": 4060
  },
  {
    "sqlState": "28000",
    "message": "[Microsoft][SQL Server Native Client 11.0][SQL Server]Login failed for user 'FakeUser'.",
    "code": 18456
  },
  {
    "sqlState": "42000",
    "message": "[Microsoft][SQL Server Native Client 11.0][SQL Server]Cannot open database \"FakeDatabase\" requested by the login. The login failed.",
    "code": 4060
  }
]
```