### PR TITLE
fix: better rendering of ConnectionError

### DIFF
--- a/lib/error/connection-error.js
+++ b/lib/error/connection-error.js
@@ -18,6 +18,12 @@ class ConnectionError extends MSSQLError {
     super(message, code)
 
     this.name = 'ConnectionError'
+
+    let err = message?.details
+    if (err instanceof Array && (err = err.at(-1))) {
+      this.message = err.message
+      this.originalError = err
+    }
   }
 }
 


### PR DESCRIPTION
supersedes https://github.com/tediousjs/node-mssql/pull/1762

---

without this PR
```
ConnectionError: [object Object]
    at PrivateConnection.callback2 (C:\Users\FakeUser\Downloads\_delme\node_modules\mssql\lib\msnodesqlv8\connection-pool.js:46:17)
    at Immediate.<anonymous> (C:\Users\FakeUser\Downloads\_delme\node_modules\msnodesqlv8\lib\connection.js:47:14)
    at process.processImmediate (node:internal/timers:485:21) {
  code: undefined
}
```

after this PR: example
```
ConnectionError: [Microsoft][SQL Server Native Client 11.0][SQL Server]Cannot open database "GenericDatabaseName" requested by the login. The login failed.
    at PrivateConnection.callback2 (C:\Users\FakeUser\Downloads\_delme\node_modules\mssql\lib\msnodesqlv8\connection-pool.js:46:17)
    at Immediate.<anonymous> (C:\Users\FakeUser\Downloads\_delme\node_modules\msnodesqlv8\lib\connection.js:47:14)
    at process.processImmediate (node:internal/timers:485:21) {
  code: undefined,
  originalError: {
    sqlState: '42000',
    message: '[Microsoft][SQL Server Native Client 11.0][SQL Server]Cannot open database "GenericDatabaseName" requested by the login. The login failed.',
    code: 4060
  }
}
```