### PR TITLE
feat: ability to change mssql_msnodesqlv8_CONNECTION_DRIVER

### DIFF
--- a/lib/msnodesqlv8/connection-pool.js
+++ b/lib/msnodesqlv8/connection-pool.js
@@ -23,7 +23,7 @@ class ConnectionPool extends BaseConnectionPool {
 
       if (!this.config.connectionString) {
         cfg.conn_str = buildConnectionString({
-          Driver: this.config.msnodesqlv8_Driver ?? this.config.DEFAULT_CONNECTION_DRIVER,
+          Driver: this.config.msnodesqlv8_Driver ?? DEFAULT_CONNECTION_DRIVER,
           Server: this.config.options.instanceName ? `${this.config.server}\\${this.config.options.instanceName}` : `${this.config.server},${this.config.port}`,
           Database: this.config.database,
           Uid: this.config.user,


### PR DESCRIPTION
Being able to override CONNECTION_DRIVER for mssql_msnodesqlv8

Windows CMD
```
set mssql_msnodesqlv8_CONNECTION_DRIVER=ODBC Driver 18 for SQL Server
node script.js
```

where script.js contains
```
const sql = require('mssql/msnodesqlv8');
```

CONNECTION_DRIVER in `.\node_modules\mssql\lib\msnodesqlv8\connection-pool.js` will get set to
`ODBC Driver 18 for SQL Server`