### PR TITLE
feat: ability to provide config.msnodesqlv8_Driver

### DIFF
--- a/lib/msnodesqlv8/connection-pool.js
+++ b/lib/msnodesqlv8/connection-pool.js
@@ -9,7 +9,7 @@ const ConnectionError = require('../error/connection-error')
 const { platform } = require('node:os')
 const { buildConnectionString } = require('@tediousjs/connection-string')
 
-const CONNECTION_DRIVER = ['darwin', 'linux'].includes(platform()) ? 'ODBC Driver 17 for SQL Server' : 'SQL Server Native Client 11.0'
+const DEFAULT_CONNECTION_DRIVER = ['darwin', 'linux'].includes(platform()) ? 'ODBC Driver 17 for SQL Server' : 'SQL Server Native Client 11.0'
 
 class ConnectionPool extends BaseConnectionPool {
   _poolCreate () {
@@ -23,7 +23,7 @@ class ConnectionPool extends BaseConnectionPool {
 
       if (!this.config.connectionString) {
         cfg.conn_str = buildConnectionString({
-          Driver: CONNECTION_DRIVER,
+          Driver: this.config.msnodesqlv8_Driver ?? DEFAULT_CONNECTION_DRIVER,
           Server: this.config.options.instanceName ? `${this.config.server}\\${this.config.options.instanceName}` : `${this.config.server},${this.config.port}`,
           Database: this.config.database,
           Uid: this.config.user,


### PR DESCRIPTION
Being able to override CONNECTION_DRIVER (now DEFAULT_CONNECTION_DRIVER) variable for mssql/msnodesqlv8

```js
const sql = require('mssql/msnodesqlv8');

const config = {
  server: "MyServer",
  database: "MyDatabase",
  options: {
    trustedConnection: true, // Set to true if using Windows Authentication
    trustServerCertificate: true, // Set to true if using self-signed certificates
  },
  driver: "msnodesqlv8", // Required if using Windows Authentication
  msnodesqlv8_Driver: "ODBC Driver 18 for SQL Server",
};

(async () => {
  try {
    await sql.connect(config);
    const result = await sql.query`select TOP 10 * from MyTable`;
    console.dir(result);
  } catch (err) {
    console.error(err);
  }
})();
```