### PR TITLE
feat: ability to provide specific config.driver for msnodesqlv8

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const config = {
     trustedConnection: true, // Set to true if using Windows Authentication
     trustServerCertificate: true, // Set to true if using self-signed certificates
   },
-  driver: "msnodesqlv8", // Required if using Windows Authentication
+  // driver: "ODBC Driver 18 for SQL Server", // Uncomment to use specific driver
 };
 
 (async () => {

--- a/lib/msnodesqlv8/connection-pool.js
+++ b/lib/msnodesqlv8/connection-pool.js
@@ -9,7 +9,7 @@ const ConnectionError = require('../error/connection-error')
 const { platform } = require('node:os')
 const { buildConnectionString } = require('@tediousjs/connection-string')
 
-const CONNECTION_DRIVER = ['darwin', 'linux'].includes(platform()) ? 'ODBC Driver 17 for SQL Server' : 'SQL Server Native Client 11.0'
+const DEFAULT_CONNECTION_DRIVER = ['darwin', 'linux'].includes(platform()) ? 'ODBC Driver 17 for SQL Server' : 'SQL Server Native Client 11.0'
 
 class ConnectionPool extends BaseConnectionPool {
   _poolCreate () {
@@ -23,7 +23,7 @@ class ConnectionPool extends BaseConnectionPool {
 
       if (!this.config.connectionString) {
         cfg.conn_str = buildConnectionString({
-          Driver: CONNECTION_DRIVER,
+          Driver: this.config.driver && this.config.driver !== 'msnodesqlv8' ? this.config.driver : DEFAULT_CONNECTION_DRIVER,
           Server: this.config.options.instanceName ? `${this.config.server}\\${this.config.options.instanceName}` : `${this.config.server},${this.config.port}`,
           Database: this.config.database,
           Uid: this.config.user,

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -241,6 +241,41 @@ describe('msnodesqlv8', function () {
     after(() => sql.close())
   })
 
+  describe('config().driver tests', function () {
+    it('cfg.driver is undefined', done => {
+      const cfg = config()
+      cfg.driver = undefined
+      sql.connect(cfg, done)
+    })
+
+    // Specifically for Windows
+    it('cfg.driver is SQL Server Native Client 11.0', done => {
+      const cfg = config()
+      cfg.driver = 'SQL Server Native Client 11.0'
+      sql.connect(cfg, done)
+    })
+
+    it('cfg.driver is invalid', done => {
+      const cfg = config()
+      cfg.driver = 'aaTESTING1234'
+
+      sql.connect(cfg, function (err) {
+        if (err) {
+          // Specifically for Windows
+          if (err.message === '[Microsoft][ODBC Driver Manager] Data source name not found and no default driver specified') {
+            return done()
+          }
+
+          return done(new Error('Incorrect error message shown'))
+        }
+
+        return done(new Error('No error message shown'))
+      })
+    })
+
+    afterEach(() => sql.close())
+  })
+
   after('cleanup', done =>
     sql.connect(config(), function (err) {
       if (err) return done(err)


### PR DESCRIPTION
Being able to override CONNECTION_DRIVER (now DEFAULT_CONNECTION_DRIVER) variable for mssql/msnodesqlv8
- while maintaining compatibility with configs with driver value "msnodesqlv8"
- if config.driver is a truthy value and not equal to "msnodesqlv8", it will use that specific driver

---
Changed README, don't know if GitHub Pages site needs an update

---

```js
const sql = require('mssql/msnodesqlv8');

const config = {
  server: "MyServer",
  database: "MyDatabase",
  options: {
    trustedConnection: true, // Set to true if using Windows Authentication
    trustServerCertificate: true, // Set to true if using self-signed certificates
  },
  driver: "ODBC Driver 18 for SQL Server",
};

(async () => {
  try {
    await sql.connect(config);
    const result = await sql.query`select TOP 10 * from MyTable`;
    console.dir(result);
  } catch (err) {
    console.error(err);
  }
})();
```