### PR TITLE
fix: show the actual error given from msnodesqlv8

### DIFF
--- a/lib/error/connection-error.js
+++ b/lib/error/connection-error.js
@@ -18,12 +18,6 @@ class ConnectionError extends MSSQLError {
     super(message, code)
 
     this.name = 'ConnectionError'
-
-    let err = message?.details
-    if (err instanceof Array && (err = err.at(-1))) {
-      this.message = err.message
-      this.originalError = err
-    }
   }
 }
 

--- a/lib/msnodesqlv8/connection-pool.js
+++ b/lib/msnodesqlv8/connection-pool.js
@@ -43,6 +43,12 @@ class ConnectionPool extends BaseConnectionPool {
 
       msnodesql.open(cfg, (err, tds) => {
         if (err) {
+          let customErr = err?.details
+          if (customErr instanceof Array && (customErr = customErr.at(-1))) {
+            err.message = customErr.message
+            err.code = customErr.code
+          }
+
           err = new ConnectionError(err.message, err.code)
           return reject(err)
         }


### PR DESCRIPTION
What this does:

- fix regression from 12.2.1 in msnodesqlv8 case
- cleanup hacky code I made for https://github.com/tediousjs/node-mssql/pull/1793 that is irrelevant since version 12.2.1

---

**in 12.2.0 / with this fix:**
```
ConnectionError: [Microsoft][SQL Server Native Client 11.0][SQL Server]Cannot open database "ExampleDB" requested by the login. The login failed.
```

**in 12.2.1 / without this fix:**
```
ConnectionError: [Microsoft][SQL Server Native Client 11.0][SQL Server]Login failed for user 'ExampleUser'.
```

---

Related issues:

https://github.com/tediousjs/node-mssql/pull/1793

Pre/Post merge checklist:

- [ ] Update change log
