### PR TITLE
fix: include schema in TVP type declaration for sp_executesql

### DIFF
--- a/lib/tedious/request.js
+++ b/lib/tedious/request.js
@@ -23,6 +23,22 @@ const N_TYPES = {
   NumericN: 0x6C
 }
 
+// Workaround for tedious TVP declaration not including schema name.
+// See: https://github.com/tediousjs/node-mssql/issues/1759
+const SchemaAwareTVP = Object.create(tds.TYPES.TVP, {
+  declaration: {
+    value: function (parameter) {
+      const value = parameter.value
+      if (value && value.schema) {
+        return value.schema + '.' + value.name + ' readonly'
+      }
+      return value.name + ' readonly'
+    },
+    writable: true,
+    configurable: true
+  }
+})
+
 const getTediousType = function (type) {
   switch (type) {
     case TYPES.VarChar: return tds.TYPES.VarChar
@@ -54,7 +70,7 @@ const getTediousType = function (type) {
     case TYPES.Binary: return tds.TYPES.Binary
     case TYPES.VarBinary: return tds.TYPES.VarBinary
     case TYPES.UDT: case TYPES.Geography: case TYPES.Geometry: return tds.TYPES.UDT
-    case TYPES.TVP: return tds.TYPES.TVP
+    case TYPES.TVP: return SchemaAwareTVP
     case TYPES.Variant: return tds.TYPES.Variant
     default: return type
   }

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -724,4 +724,142 @@ describe('connection string auth - tedious', () => {
       }
     })
   })
+
+  describe('TVP declaration with schema', () => {
+    const tds = require('tedious')
+
+    it('documents upstream tedious bug: schema missing from TVP declaration', () => {
+      const tvp = new sql.Table('AI.UDT_StringArray')
+      tvp.columns.add('Name', sql.NVarChar(128), { nullable: false })
+      tvp.rows.add('TestValue1')
+
+      const tvpValue = {
+        name: tvp.name,
+        schema: tvp.schema,
+        columns: [],
+        rows: tvp.rows
+      }
+
+      // tedious's own TVP type does NOT include schema in declaration
+      const req = new tds.Request('SELECT 1')
+      req.addParameter('InputList', tds.TYPES.TVP, tvpValue)
+      const paramsStr = req.makeParamsParameter(req.parameters)
+      assert.strictEqual(paramsStr, '@InputList UDT_StringArray readonly',
+        'tedious itself does not include schema - this documents the upstream bug')
+    })
+
+    it('schema-aware TVP type includes schema in declaration', () => {
+      const tvp = new sql.Table('AI.UDT_StringArray')
+      tvp.columns.add('Name', sql.NVarChar(128), { nullable: false })
+      tvp.rows.add('TestValue1')
+
+      const tvpValue = {
+        name: tvp.name,
+        schema: tvp.schema,
+        columns: [],
+        rows: tvp.rows
+      }
+
+      assert.strictEqual(tvp.name, 'UDT_StringArray')
+      assert.strictEqual(tvp.schema, 'AI')
+
+      // Use the patched SchemaAwareTVP type from lib/tedious/request.js
+      // Since it's not exported, recreate the same pattern to verify behavior
+      const SchemaAwareTVP = Object.create(tds.TYPES.TVP, {
+        declaration: {
+          value: function (parameter) {
+            const value = parameter.value
+            if (value && value.schema) {
+              return value.schema + '.' + value.name + ' readonly'
+            }
+            return value.name + ' readonly'
+          },
+          writable: true,
+          configurable: true
+        }
+      })
+
+      const req = new tds.Request('SELECT 1')
+      req.addParameter('InputList', SchemaAwareTVP, tvpValue)
+      const paramsStr = req.makeParamsParameter(req.parameters)
+      assert.strictEqual(paramsStr, '@InputList AI.UDT_StringArray readonly')
+    })
+
+    it('schema-aware TVP works without schema', () => {
+      const tvp = new sql.Table('UDT_StringArray')
+      tvp.columns.add('Name', sql.NVarChar(128), { nullable: false })
+
+      const tvpValue = {
+        name: tvp.name,
+        schema: tvp.schema,
+        columns: [],
+        rows: tvp.rows
+      }
+
+      assert.strictEqual(tvp.name, 'UDT_StringArray')
+      assert.strictEqual(tvp.schema, null)
+
+      const SchemaAwareTVP = Object.create(tds.TYPES.TVP, {
+        declaration: {
+          value: function (parameter) {
+            const value = parameter.value
+            if (value && value.schema) {
+              return value.schema + '.' + value.name + ' readonly'
+            }
+            return value.name + ' readonly'
+          },
+          writable: true,
+          configurable: true
+        }
+      })
+
+      const req = new tds.Request('SELECT 1')
+      req.addParameter('InputList', SchemaAwareTVP, tvpValue)
+      const paramsStr = req.makeParamsParameter(req.parameters)
+      assert.strictEqual(paramsStr, '@InputList UDT_StringArray readonly')
+    })
+
+    it('schema-aware TVP inherits generateTypeInfo from tedious TVP', () => {
+      const SchemaAwareTVP = Object.create(tds.TYPES.TVP, {
+        declaration: {
+          value: function (parameter) {
+            const value = parameter.value
+            if (value && value.schema) {
+              return value.schema + '.' + value.name + ' readonly'
+            }
+            return value.name + ' readonly'
+          },
+          writable: true,
+          configurable: true
+        }
+      })
+
+      // Verify it inherits all other methods from tedious TVP
+      assert.strictEqual(SchemaAwareTVP.id, tds.TYPES.TVP.id)
+      assert.strictEqual(SchemaAwareTVP.type, tds.TYPES.TVP.type)
+      assert.strictEqual(SchemaAwareTVP.name, tds.TYPES.TVP.name)
+      assert.strictEqual(SchemaAwareTVP.generateTypeInfo, tds.TYPES.TVP.generateTypeInfo)
+      assert.strictEqual(SchemaAwareTVP.generateParameterLength, tds.TYPES.TVP.generateParameterLength)
+      assert.strictEqual(SchemaAwareTVP.generateParameterData, tds.TYPES.TVP.generateParameterData)
+      assert.strictEqual(SchemaAwareTVP.validate, tds.TYPES.TVP.validate)
+      // declaration is overridden
+      assert.notStrictEqual(SchemaAwareTVP.declaration, tds.TYPES.TVP.declaration)
+    })
+  })
+
+  describe('msnodesqlv8 TVP declaration', () => {
+    const { declare, TYPES } = require('../../lib/datatypes')
+
+    it('includes schema in TVP declaration when tvpType is schema-qualified', () => {
+      // msnodesqlv8 uses declare() from datatypes.js, which uses tvpType
+      // When tvpType includes the schema, the declaration is correct
+      const result = declare(TYPES.TVP, { tvpType: 'AI.UDT_StringArray' })
+      assert.strictEqual(result, 'AI.UDT_StringArray readonly')
+    })
+
+    it('works without schema in tvpType', () => {
+      const result = declare(TYPES.TVP, { tvpType: 'UDT_StringArray' })
+      assert.strictEqual(result, 'UDT_StringArray readonly')
+    })
+  })
 })


### PR DESCRIPTION
Fixes #1759. When using TVPs with schema-qualified UDT names (e.g. AI.UDT_StringArray), the schema was omitted from the @params string in sp_executesql, causing 'Cannot find data type' errors.

Root cause: tedious's TVP declaration function only uses value.name, ignoring value.schema. This creates a SchemaAwareTVP type that inherits all behavior from tedious's TVP type but overrides declaration to include the schema when present.

The fix does not affect the execute() path (stored procedures via RPC protocol) which already handles schema correctly via generateTypeInfo. Only the query() path using sp_executesql was affected.

What this does:

<!-- Describe the PR -->

Related issues:

<!-- Provide links to any related issues or issues being closed by this PR -->

Pre/Post merge checklist:

- [ ] Update change log
