### PR TITLE
fix: reset sql.Promise after custom promise library test

### DIFF
--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -123,6 +123,7 @@ describe('Unit', () => {
     sql.Promise = FakePromise
     sql.close().then(() => {
       assert.strictEqual(resolved, true)
+      sql.Promise = Promise
       done()
     })
   })


### PR DESCRIPTION
The 'custom promise library' test sets sql.Promise to a FakePromise class but never restores it. This leaks into subsequent tests that rely on shared.Promise being the native Promise, causing failures when tests use _poolValidate or other code paths that create promises via the shared module.

What this does:

<!-- Describe the PR -->

Related issues:

<!-- Provide links to any related issues or issues being closed by this PR -->

Pre/Post merge checklist:

- [ ] Update change log
