### PR TITLE
ci: add sqlserver 2025 to the linux matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         node: [18.x, 20.x, 22.x, 24.x]
-        sqlserver: [2019, 2022]
+        sqlserver: [2019, 2022, 2025]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
What this does:

Add sql server 2025 tests
