### PR TITLE
feat: add diagnostics_channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2259,7 +2259,9 @@ dc.subscribe(`tracing:${CHANNELS.TRACE_QUERY}:error`, ({ requestId, error }) => 
 | `TRACE_PREPARE` | `mssql:prepare` | `ps.prepare()` |
 | `TRACE_PREPARED_EXECUTE` | `mssql:prepared-execute` | `ps.execute()` |
 
-TracingChannel contexts include identifiers (`requestId`, `connectionId`, `poolId`), operation details (SQL text, procedure name, parameter names), and — on completion — `result` or `error`. Parameter **values** are never included. SQL text is included to support OTel `db.query.text` conventions but may contain inline literals; consumers should consider redaction.
+TracingChannel contexts include identifiers (`requestId`, `poolId`), operation details (SQL text, procedure name, parameter names), and — on completion — `result` or `error`. Parameter **values** are never included. SQL text is included to support OTel `db.query.text` conventions but may contain inline literals; consumers should consider redaction. Connection-level identifiers are available through the `connection:acquire` / `connection:release` point-event channels.
+
+> **Note:** TracingChannel instrumentation is active on the **promise** API. If you use the callback API, TracingChannel events will not fire for those calls. Point-event channels (connection, transaction, pool lifecycle) fire regardless of API style.
 
 ### Point-event channels
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ const config = {
 * [Metadata](#metadata)
 * [Data Types](#data-types)
 * [SQL injection](#sql-injection)
+* [Diagnostics Channel](#diagnostics-channel)
 * [Contributing](https://github.com/tediousjs/node-mssql/wiki/Contributing)
 * [11.x to 12.x changes](#11x-to-12x-changes)
 * [10.x to 11.x changes](#10x-to-11x-changes)
@@ -2217,6 +2218,97 @@ const request = new sql.Request()
 request.input('myval', sql.VarChar, '-- commented')
 request.query('select @myval as myval', (err, result) => {
     console.dir(result)
+})
+```
+
+## Diagnostics Channel
+
+node-mssql publishes telemetry through Node.js [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html), enabling APM tools and custom instrumentation to observe queries, connections, and internal events without modifying application code. When no subscribers are active, overhead is near-zero.
+
+All channel name constants are exported from the package:
+
+```js
+const { CHANNELS } = require('mssql')
+```
+
+### TracingChannels (async lifecycle)
+
+These use [`TracingChannel`](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel) to wrap async operations, emitting `start`, `end`, `asyncStart`, `asyncEnd`, and `error` sub-events. Subscribe via `tracing:<name>:<event>`:
+
+```js
+const dc = require('node:diagnostics_channel')
+const { CHANNELS } = require('mssql')
+
+dc.subscribe(`tracing:${CHANNELS.TRACE_QUERY}:start`, ({ command, requestId }) => {
+  console.log(`[${requestId}] Query: ${command}`)
+})
+
+dc.subscribe(`tracing:${CHANNELS.TRACE_QUERY}:error`, ({ requestId, error }) => {
+  console.error(`[${requestId}] Failed:`, error.message)
+})
+```
+
+| Constant | Channel name | Wraps |
+|---|---|---|
+| `TRACE_QUERY` | `mssql:query` | `request.query()` |
+| `TRACE_BATCH` | `mssql:batch` | `request.batch()` |
+| `TRACE_EXECUTE` | `mssql:execute` | `request.execute()` |
+| `TRACE_BULK` | `mssql:bulk` | `request.bulk()` |
+| `TRACE_CONNECT` | `mssql:connect` | `pool.connect()` |
+| `TRACE_POOL_ACQUIRE` | `mssql:pool:acquire` | Pool connection acquire (wait time) |
+| `TRACE_PREPARE` | `mssql:prepare` | `ps.prepare()` |
+| `TRACE_PREPARED_EXECUTE` | `mssql:prepared-execute` | `ps.execute()` |
+
+TracingChannel contexts include identifiers (`requestId`, `connectionId`, `poolId`), operation details (SQL text, procedure name, parameter names), and — on completion — `result` or `error`. Parameter **values** are never included. SQL text is included to support OTel `db.query.text` conventions but may contain inline literals; consumers should consider redaction.
+
+### Point-event channels
+
+These emit single events at state transitions via `dc.subscribe()`:
+
+```js
+dc.subscribe(CHANNELS.CONNECTION_RELEASE, ({ connectionId, poolId, duration }) => {
+  console.log(`Pool ${poolId}: connection ${connectionId} released after ${duration}ms`)
+})
+```
+
+| Constant | Channel name | Description |
+|---|---|---|
+| `CONNECTION_ACQUIRE` | `mssql:connection:acquire` | Connection borrowed from pool |
+| `CONNECTION_RELEASE` | `mssql:connection:release` | Connection returned to pool (includes `duration` in ms) |
+| `CONNECTION_CREATE` | `mssql:connection:create` | New connection created in pool |
+| `CONNECTION_DESTROY` | `mssql:connection:destroy` | Connection destroyed |
+| `POOL_CLOSE` | `mssql:pool:close` | Pool closed |
+| `TRANSACTION_BEGIN` | `mssql:transaction:begin` | Transaction begun (includes `isolationLevel`) |
+| `TRANSACTION_COMMIT` | `mssql:transaction:commit` | Transaction committed |
+| `TRANSACTION_ROLLBACK` | `mssql:transaction:rollback` | Transaction rolled back (includes `aborted` flag) |
+| `REQUEST_CANCEL` | `mssql:request:cancel` | Request cancelled |
+| `PREPARED_STATEMENT_UNPREPARE` | `mssql:prepared-statement:unprepare` | Prepared statement released |
+
+### Example: OpenTelemetry Spans
+
+```js
+const dc = require('node:diagnostics_channel')
+const { trace, SpanKind, SpanStatusCode } = require('@opentelemetry/api')
+const { CHANNELS } = require('mssql')
+
+const tracer = trace.getTracer('mssql')
+const queryTC = dc.tracingChannel(CHANNELS.TRACE_QUERY)
+
+queryTC.subscribe({
+  start (ctx) {
+    ctx.span = tracer.startSpan('mssql.query', {
+      kind: SpanKind.CLIENT,
+      attributes: { 'db.system': 'mssql', 'db.query.text': ctx.command },
+    })
+  },
+  asyncEnd (ctx) { ctx.span?.end() },
+  error (ctx) {
+    if (ctx.span) {
+      ctx.span.recordException(ctx.error)
+      ctx.span.setStatus({ code: SpanStatusCode.ERROR })
+      ctx.span.end()
+    }
+  },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -2265,7 +2265,7 @@ TracingChannel contexts include identifiers (`requestId`, `poolId`), operation d
 
 > **Note on identifiers:** `connectionId`, `poolId`, `requestId`, `transactionId`, and `preparedStatementId` are monotonically increasing integers scoped to the current node process. They are not stable across restarts and cannot be used to correlate activity across processes.
 
-> **Note:** TracingChannel instrumentation is active on the **promise** API. If you use the callback API, TracingChannel events will not fire for those calls. Point-event channels (connection, transaction, pool lifecycle) fire regardless of API style.
+> **Note:** TracingChannel instrumentation fires for both the promise and callback APIs. The callback API is traced via Node's `TracingChannel#traceCallback`, which emits the same `start` / `end` / `asyncStart` / `asyncEnd` / `error` sub-events as the promise path, so subscribers do not need to branch by API style. Point-event channels (connection, transaction, pool lifecycle) likewise fire regardless of API style.
 
 ### Point-event channels
 

--- a/README.md
+++ b/README.md
@@ -2256,8 +2256,8 @@ dc.subscribe(`tracing:${CHANNELS.TRACE_QUERY}:error`, ({ requestId, error }) => 
 | `TRACE_BULK` | `mssql:bulk` | `request.bulk()` |
 | `TRACE_CONNECT` | `mssql:connect` | `pool.connect()` |
 | `TRACE_POOL_ACQUIRE` | `mssql:pool:acquire` | Pool connection acquire (wait time) |
-| `TRACE_PREPARE` | `mssql:prepare` | `ps.prepare()` |
-| `TRACE_PREPARED_EXECUTE` | `mssql:prepared-execute` | `ps.execute()` |
+| `TRACE_PREPARED_STATEMENT_PREPARE` | `mssql:prepared-statement:prepare` | `ps.prepare()` |
+| `TRACE_PREPARED_STATEMENT_EXECUTE` | `mssql:prepared-statement:execute` | `ps.execute()` |
 
 TracingChannel contexts include identifiers (`requestId`, `poolId`), operation details (SQL text, procedure name, parameter names), and — on completion — `result` or `error`. Parameter **values** are never included. SQL text is included to support OTel `db.query.text` conventions but may contain inline literals; consumers should consider redaction. Connection-level identifiers are available through the `connection:acquire` / `connection:release` point-event channels.
 

--- a/README.md
+++ b/README.md
@@ -2259,7 +2259,11 @@ dc.subscribe(`tracing:${CHANNELS.TRACE_QUERY}:error`, ({ requestId, error }) => 
 | `TRACE_PREPARED_STATEMENT_PREPARE` | `mssql:prepared-statement:prepare` | `ps.prepare()` |
 | `TRACE_PREPARED_STATEMENT_EXECUTE` | `mssql:prepared-statement:execute` | `ps.execute()` |
 
-TracingChannel contexts include identifiers (`requestId`, `poolId`), operation details (SQL text, procedure name, parameter names), and — on completion — `result` or `error`. Parameter **values** are never included. SQL text is included to support OTel `db.query.text` conventions but may contain inline literals; consumers should consider redaction. Connection-level identifiers are available through the `connection:acquire` / `connection:release` point-event channels.
+TracingChannel contexts include identifiers (`requestId`, `poolId`), operation details (SQL text, procedure name, parameter names), and — on completion — `result` or `error`. Parameter **values** are never included (only their names).
+
+> **Note on SQL text in trace contexts:** `command` / `procedure` / `statement` fields contain the SQL text as sent to the server, to support OTel `db.query.text` conventions. Because node-mssql is parameterised-query-first, user-supplied values flow through `parameters` and do not appear in the SQL text. Avoid hard-coding credentials, tokens, or PII as inline SQL literals — anything hard-coded into a raw query will appear verbatim in trace contexts.
+
+> **Note on identifiers:** `connectionId`, `poolId`, `requestId`, `transactionId`, and `preparedStatementId` are monotonically increasing integers scoped to the current node process. They are not stable across restarts and cannot be used to correlate activity across processes.
 
 > **Note:** TracingChannel instrumentation is active on the **promise** API. If you use the callback API, TracingChannel events will not fire for those calls. Point-event channels (connection, transaction, pool lifecycle) fire regardless of API style.
 
@@ -2279,8 +2283,8 @@ dc.subscribe(CHANNELS.CONNECTION_RELEASE, ({ connectionId, poolId }) => {
 | `CONNECTION_RELEASE` | `mssql:connection:release` | Connection returned to pool |
 | `CONNECTION_CREATE` | `mssql:connection:create` | New connection created in pool |
 | `CONNECTION_DESTROY` | `mssql:connection:destroy` | Connection destroyed |
-| `POOL_CLOSE` | `mssql:pool:close` | Pool closed |
-| `TRANSACTION_BEGIN` | `mssql:transaction:begin` | Transaction begun (includes `isolationLevel`) |
+| `POOL_CLOSE` | `mssql:pool:close` | Pool closed (includes `reason`: `'closed'` or `'error'`; `error` on failure) |
+| `TRANSACTION_BEGIN` | `mssql:transaction:begin` | Transaction begun (includes numeric `isolationLevel` and `isolationLevelName`) |
 | `TRANSACTION_COMMIT` | `mssql:transaction:commit` | Transaction committed |
 | `TRANSACTION_ROLLBACK` | `mssql:transaction:rollback` | Transaction rolled back (includes `aborted` flag) |
 | `REQUEST_CANCEL` | `mssql:request:cancel` | Request cancelled |

--- a/README.md
+++ b/README.md
@@ -2268,15 +2268,15 @@ TracingChannel contexts include identifiers (`requestId`, `poolId`), operation d
 These emit single events at state transitions via `dc.subscribe()`:
 
 ```js
-dc.subscribe(CHANNELS.CONNECTION_RELEASE, ({ connectionId, poolId, duration }) => {
-  console.log(`Pool ${poolId}: connection ${connectionId} released after ${duration}ms`)
+dc.subscribe(CHANNELS.CONNECTION_RELEASE, ({ connectionId, poolId }) => {
+  console.log(`Pool ${poolId}: connection ${connectionId} released`)
 })
 ```
 
 | Constant | Channel name | Description |
 |---|---|---|
 | `CONNECTION_ACQUIRE` | `mssql:connection:acquire` | Connection borrowed from pool |
-| `CONNECTION_RELEASE` | `mssql:connection:release` | Connection returned to pool (includes `duration` in ms) |
+| `CONNECTION_RELEASE` | `mssql:connection:release` | Connection returned to pool |
 | `CONNECTION_CREATE` | `mssql:connection:create` | New connection created in pool |
 | `CONNECTION_DESTROY` | `mssql:connection:destroy` | Connection destroyed |
 | `POOL_CLOSE` | `mssql:pool:close` | Pool closed |

--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -8,6 +8,7 @@ const { IDS } = require('../utils')
 const ConnectionError = require('../error/connection-error')
 const shared = require('../shared')
 const { MSSQLError } = require('../error')
+const { CHANNELS, tracePromise, publish } = require('../diagnostics')
 
 /**
  * Class ConnectionPool.
@@ -371,10 +372,30 @@ class ConnectionPool extends EventEmitter {
    */
 
   acquire (requester, callback) {
-    const acquirePromise = shared.Promise.resolve(this._acquire()).catch(err => {
-      this.emit('error', err)
-      throw err
+    const requestId = IDS.get(requester)
+    const poolId = IDS.get(this)
+
+    const acquirePromise = tracePromise(CHANNELS.TRACE_POOL_ACQUIRE, () => {
+      return shared.Promise.resolve(this._acquire()).catch(err => {
+        this.emit('error', err)
+        throw err
+      }).then(connection => {
+        const connectionId = IDS.get(connection)
+        const acquiredAt = process.hrtime.bigint()
+        publish(CHANNELS.CONNECTION_ACQUIRE, () => ({
+          connectionId,
+          requestId,
+          poolId,
+          acquiredAt
+        }))
+        connection._poolAcquiredAt = acquiredAt
+        return connection
+      })
+    }, {
+      poolId,
+      requestId
     })
+
     if (typeof callback === 'function') {
       acquirePromise.then(connection => callback(null, connection, this.config)).catch(callback)
       return this
@@ -403,6 +424,18 @@ class ConnectionPool extends EventEmitter {
   release (connection) {
     debug('connection(%d): released', IDS.get(connection))
 
+    if (connection._poolAcquiredAt) {
+      const now = process.hrtime.bigint()
+      const durationMs = Number(now - connection._poolAcquiredAt) / 1e6
+      publish(CHANNELS.CONNECTION_RELEASE, () => ({
+        connectionId: IDS.get(connection),
+        poolId: IDS.get(this),
+        acquiredAt: connection._poolAcquiredAt,
+        duration: durationMs
+      }))
+      connection._poolAcquiredAt = undefined
+    }
+
     if (this.pool) {
       this.pool.release(connection)
     }
@@ -422,11 +455,22 @@ class ConnectionPool extends EventEmitter {
       return this
     }
 
-    return new shared.Promise((resolve, reject) => {
-      return this._connect(err => {
-        if (err) return reject(err)
-        resolve(this)
+    return tracePromise(CHANNELS.TRACE_CONNECT, () => {
+      return new shared.Promise((resolve, reject) => {
+        return this._connect(err => {
+          if (err) return reject(err)
+          resolve(this)
+        })
       })
+    }, {
+      server: this.config.server,
+      port: this.config.port,
+      database: this.config.database,
+      poolId: IDS.get(this),
+      poolConfig: {
+        min: (this.config.pool && this.config.pool.min) || 0,
+        max: (this.config.pool && this.config.pool.max) || 10
+      }
     })
   }
 
@@ -559,6 +603,9 @@ class ConnectionPool extends EventEmitter {
 
     this.pool.destroy().then(() => {
       debug('pool(%d): pool closed, removing pool reference and executing close callbacks', IDS.get(this))
+      publish(CHANNELS.POOL_CLOSE, () => ({
+        poolId: IDS.get(this)
+      }))
       this.pool = null
       this._closeStack.forEach(cb => {
         setImmediate(cb, null)

--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -593,13 +593,19 @@ class ConnectionPool extends EventEmitter {
     this.pool.destroy().then(() => {
       debug('pool(%d): pool closed, removing pool reference and executing close callbacks', IDS.get(this))
       publish(CHANNELS.POOL_CLOSE, () => ({
-        poolId: IDS.get(this)
+        poolId: IDS.get(this),
+        reason: 'closed'
       }))
       this.pool = null
       this._closeStack.forEach(cb => {
         setImmediate(cb, null)
       })
     }).catch(err => {
+      publish(CHANNELS.POOL_CLOSE, () => ({
+        poolId: IDS.get(this),
+        reason: 'error',
+        error: err
+      }))
       this.pool = null
       this._closeStack.forEach(cb => {
         setImmediate(cb, err)

--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -8,7 +8,7 @@ const { IDS } = require('../utils')
 const ConnectionError = require('../error/connection-error')
 const shared = require('../shared')
 const { MSSQLError } = require('../error')
-const { CHANNELS, tracePromise, publish } = require('../diagnostics')
+const { CHANNELS, tracePromise, traceCallback, publish } = require('../diagnostics')
 
 /**
  * Class ConnectionPool.
@@ -440,7 +440,16 @@ class ConnectionPool extends EventEmitter {
 
   connect (callback) {
     if (typeof callback === 'function') {
-      this._connect(callback)
+      traceCallback(CHANNELS.TRACE_CONNECT, this._connect, 0, () => ({
+        server: this.config.server,
+        port: this.config.port,
+        database: this.config.database,
+        poolId: IDS.get(this),
+        poolConfig: {
+          min: (this.config.pool && this.config.pool.min) || 0,
+          max: (this.config.pool && this.config.pool.max) || 10
+        }
+      }), this, [callback])
       return this
     }
 

--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -380,21 +380,17 @@ class ConnectionPool extends EventEmitter {
         this.emit('error', err)
         throw err
       }).then(connection => {
-        const connectionId = IDS.get(connection)
-        const acquiredAt = process.hrtime.bigint()
         publish(CHANNELS.CONNECTION_ACQUIRE, () => ({
-          connectionId,
+          connectionId: IDS.get(connection),
           requestId,
-          poolId,
-          acquiredAt
+          poolId
         }))
-        connection._poolAcquiredAt = acquiredAt
         return connection
       })
-    }, {
+    }, () => ({
       poolId,
       requestId
-    })
+    }))
 
     if (typeof callback === 'function') {
       acquirePromise.then(connection => callback(null, connection, this.config)).catch(callback)
@@ -424,17 +420,10 @@ class ConnectionPool extends EventEmitter {
   release (connection) {
     debug('connection(%d): released', IDS.get(connection))
 
-    if (connection._poolAcquiredAt) {
-      const now = process.hrtime.bigint()
-      const durationMs = Number(now - connection._poolAcquiredAt) / 1e6
-      publish(CHANNELS.CONNECTION_RELEASE, () => ({
-        connectionId: IDS.get(connection),
-        poolId: IDS.get(this),
-        acquiredAt: connection._poolAcquiredAt,
-        duration: durationMs
-      }))
-      connection._poolAcquiredAt = undefined
-    }
+    publish(CHANNELS.CONNECTION_RELEASE, () => ({
+      connectionId: IDS.get(connection),
+      poolId: IDS.get(this)
+    }))
 
     if (this.pool) {
       this.pool.release(connection)
@@ -462,7 +451,7 @@ class ConnectionPool extends EventEmitter {
           resolve(this)
         })
       })
-    }, {
+    }, () => ({
       server: this.config.server,
       port: this.config.port,
       database: this.config.database,
@@ -471,7 +460,7 @@ class ConnectionPool extends EventEmitter {
         min: (this.config.pool && this.config.pool.min) || 0,
         max: (this.config.pool && this.config.pool.max) || 10
       }
-    })
+    }))
   }
 
   /**

--- a/lib/base/index.js
+++ b/lib/base/index.js
@@ -10,6 +10,7 @@ const Table = require('../table')
 const ISOLATION_LEVEL = require('../isolationlevel')
 const { TYPES } = require('../datatypes')
 const { connect, close, on, off, removeListener, query, batch } = require('../global-connection')
+const { CHANNELS } = require('../diagnostics')
 
 module.exports = {
   ConnectionPool,
@@ -31,6 +32,7 @@ module.exports = {
     Table,
     ISOLATION_LEVEL,
     TYPES,
+    CHANNELS,
     MAX: 65535, // (1 << 16) - 1
     map: shared.map,
     getTypeByValue: shared.getTypeByValue,

--- a/lib/base/prepared-statement.js
+++ b/lib/base/prepared-statement.js
@@ -214,12 +214,12 @@ class PreparedStatement extends EventEmitter {
           resolve(this)
         })
       })
-    }, {
+    }, () => ({
       statement: statement || this.statement,
       parameters: Object.keys(this.parameters),
       preparedStatementId: IDS.get(this),
       poolId: this._getPoolId()
-    })
+    }))
   }
 
   /**
@@ -303,13 +303,13 @@ class PreparedStatement extends EventEmitter {
           resolve(recordset)
         })
       })
-    }, {
+    }, () => ({
       statement: this.statement,
       parameters: Object.keys(this.parameters),
       handle: this._handle,
       preparedStatementId: IDS.get(this),
       poolId: this._getPoolId()
-    })
+    }))
   }
 
   /**

--- a/lib/base/prepared-statement.js
+++ b/lib/base/prepared-statement.js
@@ -7,6 +7,7 @@ const globalConnection = require('../global-connection')
 const { TransactionError, PreparedStatementError } = require('../error')
 const shared = require('../shared')
 const { TYPES, declare } = require('../datatypes')
+const { CHANNELS, tracePromise, publish } = require('../diagnostics')
 
 /**
  * Class PreparedStatement.
@@ -184,6 +185,14 @@ class PreparedStatement extends EventEmitter {
     return this.output(name, type)
   }
 
+  _getPoolId () {
+    let parent = this.parent
+    while (parent && !parent.pool) {
+      parent = parent.parent
+    }
+    return parent ? IDS.get(parent) : undefined
+  }
+
   /**
    * Prepare a statement.
    *
@@ -198,11 +207,18 @@ class PreparedStatement extends EventEmitter {
       return this
     }
 
-    return new shared.Promise((resolve, reject) => {
-      this._prepare(statement, err => {
-        if (err) return reject(err)
-        resolve(this)
+    return tracePromise(CHANNELS.TRACE_PREPARE, () => {
+      return new shared.Promise((resolve, reject) => {
+        this._prepare(statement, err => {
+          if (err) return reject(err)
+          resolve(this)
+        })
       })
+    }, {
+      statement: statement || this.statement,
+      parameters: Object.keys(this.parameters),
+      preparedStatementId: IDS.get(this),
+      poolId: this._getPoolId()
     })
   }
 
@@ -233,6 +249,7 @@ class PreparedStatement extends EventEmitter {
       this._acquiredConfig = config
 
       const req = new shared.driver.Request(this)
+      req._internal = true
       req.stream = false
       req.output('handle', TYPES.Int)
       req.input('params', TYPES.NVarChar, ((() => {
@@ -279,11 +296,19 @@ class PreparedStatement extends EventEmitter {
       return this._execute(values, callback)
     }
 
-    return new shared.Promise((resolve, reject) => {
-      this._execute(values, (err, recordset) => {
-        if (err) return reject(err)
-        resolve(recordset)
+    return tracePromise(CHANNELS.TRACE_PREPARED_EXECUTE, () => {
+      return new shared.Promise((resolve, reject) => {
+        this._execute(values, (err, recordset) => {
+          if (err) return reject(err)
+          resolve(recordset)
+        })
       })
+    }, {
+      statement: this.statement,
+      parameters: Object.keys(this.parameters),
+      handle: this._handle,
+      preparedStatementId: IDS.get(this),
+      poolId: this._getPoolId()
     })
   }
 
@@ -295,6 +320,7 @@ class PreparedStatement extends EventEmitter {
 
   _execute (values, callback) {
     const req = new shared.driver.Request(this)
+    req._internal = true
     req.stream = this.stream
     req.arrayRowMode = this.arrayRowMode
     req.input('handle', TYPES.Int, this._handle)
@@ -334,13 +360,25 @@ class PreparedStatement extends EventEmitter {
 
   unprepare (callback) {
     if (typeof callback === 'function') {
-      this._unprepare(callback)
+      this._unprepare(err => {
+        if (!err) {
+          publish(CHANNELS.PREPARED_STATEMENT_UNPREPARE, () => ({
+            preparedStatementId: IDS.get(this),
+            poolId: this._getPoolId()
+          }))
+        }
+        callback(err)
+      })
       return this
     }
 
     return new shared.Promise((resolve, reject) => {
       this._unprepare(err => {
         if (err) return reject(err)
+        publish(CHANNELS.PREPARED_STATEMENT_UNPREPARE, () => ({
+          preparedStatementId: IDS.get(this),
+          poolId: this._getPoolId()
+        }))
         resolve()
       })
     })
@@ -363,6 +401,7 @@ class PreparedStatement extends EventEmitter {
     }
 
     const req = new shared.driver.Request(this)
+    req._internal = true
     req.stream = false
     req.input('handle', TYPES.Int, this._handle)
     req.execute('sp_unprepare', err => {

--- a/lib/base/prepared-statement.js
+++ b/lib/base/prepared-statement.js
@@ -199,7 +199,7 @@ class PreparedStatement extends EventEmitter {
       return this
     }
 
-    return tracePromise(CHANNELS.TRACE_PREPARE, () => {
+    return tracePromise(CHANNELS.TRACE_PREPARED_STATEMENT_PREPARE, () => {
       return new shared.Promise((resolve, reject) => {
         this._prepare(statement, err => {
           if (err) return reject(err)
@@ -288,7 +288,7 @@ class PreparedStatement extends EventEmitter {
       return this._execute(values, callback)
     }
 
-    return tracePromise(CHANNELS.TRACE_PREPARED_EXECUTE, () => {
+    return tracePromise(CHANNELS.TRACE_PREPARED_STATEMENT_EXECUTE, () => {
       return new shared.Promise((resolve, reject) => {
         this._execute(values, (err, recordset) => {
           if (err) return reject(err)

--- a/lib/base/prepared-statement.js
+++ b/lib/base/prepared-statement.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('mssql:base')
 const { EventEmitter } = require('node:events')
-const { IDS, objectHasProperty } = require('../utils')
+const { IDS, objectHasProperty, getPoolId } = require('../utils')
 const globalConnection = require('../global-connection')
 const { TransactionError, PreparedStatementError } = require('../error')
 const shared = require('../shared')
@@ -185,14 +185,6 @@ class PreparedStatement extends EventEmitter {
     return this.output(name, type)
   }
 
-  _getPoolId () {
-    let parent = this.parent
-    while (parent && !parent.pool) {
-      parent = parent.parent
-    }
-    return parent ? IDS.get(parent) : undefined
-  }
-
   /**
    * Prepare a statement.
    *
@@ -218,7 +210,7 @@ class PreparedStatement extends EventEmitter {
       statement: statement || this.statement,
       parameters: Object.keys(this.parameters),
       preparedStatementId: IDS.get(this),
-      poolId: this._getPoolId()
+      poolId: getPoolId(this)
     }))
   }
 
@@ -308,7 +300,7 @@ class PreparedStatement extends EventEmitter {
       parameters: Object.keys(this.parameters),
       handle: this._handle,
       preparedStatementId: IDS.get(this),
-      poolId: this._getPoolId()
+      poolId: getPoolId(this)
     }))
   }
 
@@ -364,7 +356,7 @@ class PreparedStatement extends EventEmitter {
         if (!err) {
           publish(CHANNELS.PREPARED_STATEMENT_UNPREPARE, () => ({
             preparedStatementId: IDS.get(this),
-            poolId: this._getPoolId()
+            poolId: getPoolId(this)
           }))
         }
         callback(err)
@@ -377,7 +369,7 @@ class PreparedStatement extends EventEmitter {
         if (err) return reject(err)
         publish(CHANNELS.PREPARED_STATEMENT_UNPREPARE, () => ({
           preparedStatementId: IDS.get(this),
-          poolId: this._getPoolId()
+          poolId: getPoolId(this)
         }))
         resolve()
       })

--- a/lib/base/prepared-statement.js
+++ b/lib/base/prepared-statement.js
@@ -7,7 +7,7 @@ const globalConnection = require('../global-connection')
 const { TransactionError, PreparedStatementError } = require('../error')
 const shared = require('../shared')
 const { TYPES, declare } = require('../datatypes')
-const { CHANNELS, tracePromise, publish } = require('../diagnostics')
+const { CHANNELS, tracePromise, traceCallback, publish } = require('../diagnostics')
 
 /**
  * Class PreparedStatement.
@@ -195,7 +195,12 @@ class PreparedStatement extends EventEmitter {
 
   prepare (statement, callback) {
     if (typeof callback === 'function') {
-      this._prepare(statement, callback)
+      traceCallback(CHANNELS.TRACE_PREPARED_STATEMENT_PREPARE, this._prepare, 1, () => ({
+        statement: statement || this.statement,
+        parameters: Object.keys(this.parameters),
+        preparedStatementId: IDS.get(this),
+        poolId: getPoolId(this)
+      }), this, [statement, callback])
       return this
     }
 
@@ -285,7 +290,19 @@ class PreparedStatement extends EventEmitter {
 
   execute (values, callback) {
     if (this.stream || (typeof callback === 'function')) {
-      return this._execute(values, callback)
+      if (typeof callback !== 'function') {
+        // Stream mode without a callback: no async boundary for traceCallback
+        // to hook — fall through to the untraced call. Subscribers interested
+        // in streaming completion should listen to Request events.
+        return this._execute(values, callback)
+      }
+      return traceCallback(CHANNELS.TRACE_PREPARED_STATEMENT_EXECUTE, this._execute, 1, () => ({
+        statement: this.statement,
+        parameters: Object.keys(this.parameters),
+        handle: this._handle,
+        preparedStatementId: IDS.get(this),
+        poolId: getPoolId(this)
+      }), this, [values, callback])
     }
 
     return tracePromise(CHANNELS.TRACE_PREPARED_STATEMENT_EXECUTE, () => {

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -8,7 +8,7 @@ const globalConnection = require('../global-connection')
 const { RequestError, ConnectionError } = require('../error')
 const { TYPES } = require('../datatypes')
 const shared = require('../shared')
-const { CHANNELS, tracePromise, publish } = require('../diagnostics')
+const { CHANNELS, tracePromise, traceCallback, publish } = require('../diagnostics')
 
 /**
  * Class Request.
@@ -231,6 +231,13 @@ class Request extends EventEmitter {
     return tracePromise(channel, fn, contextFactory)
   }
 
+  _tracedCallback (channel, contextFactory, fn, position, args) {
+    if (this._internal) {
+      return fn.apply(this, args)
+    }
+    return traceCallback(channel, fn, position, contextFactory, this, args)
+  }
+
   /**
    * Execute the SQL batch.
    *
@@ -245,7 +252,11 @@ class Request extends EventEmitter {
     this.rowsAffected = 0
 
     if (typeof callback === 'function') {
-      this._batch(batch, (err, recordsets, output, rowsAffected) => {
+      this._tracedCallback(CHANNELS.TRACE_BATCH, () => ({
+        command: batch,
+        requestId: IDS.get(this),
+        poolId: getPoolId(this)
+      }), this._batch, 1, [batch, (err, recordsets, output, rowsAffected) => {
         if (this.stream) {
           if (err) this.emit('error', err)
           err = null
@@ -263,7 +274,7 @@ class Request extends EventEmitter {
           output,
           rowsAffected
         })
-      })
+      }])
       return this
     }
 
@@ -344,7 +355,12 @@ class Request extends EventEmitter {
     if (this.arrayRowMode === null && this.parent) this.arrayRowMode = this.parent.config.arrayRowMode
 
     if (this.stream || typeof callback === 'function') {
-      this._bulk(table, options, (err, rowsAffected) => {
+      this._tracedCallback(CHANNELS.TRACE_BULK, () => ({
+        table: table.path || table.name,
+        rowCount: table.rows ? table.rows.length : 0,
+        requestId: IDS.get(this),
+        poolId: getPoolId(this)
+      }), this._bulk, 2, [table, options, (err, rowsAffected) => {
         if (this.stream) {
           if (err) this.emit('error', err)
           return this.emit('done', {
@@ -356,7 +372,7 @@ class Request extends EventEmitter {
         callback(null, {
           rowsAffected
         })
-      })
+      }])
       return this
     }
 
@@ -456,7 +472,12 @@ class Request extends EventEmitter {
     this.rowsAffected = 0
 
     if (typeof callback === 'function') {
-      this._query(command, (err, recordsets, output, rowsAffected, columns) => {
+      this._tracedCallback(CHANNELS.TRACE_QUERY, () => ({
+        command,
+        parameters: this._getParameterNames(),
+        requestId: IDS.get(this),
+        poolId: getPoolId(this)
+      }), this._query, 1, [command, (err, recordsets, output, rowsAffected, columns) => {
         if (this.stream) {
           if (err) this.emit('error', err)
           err = null
@@ -476,7 +497,7 @@ class Request extends EventEmitter {
         }
         if (this.arrayRowMode) result.columns = columns
         callback(null, result)
-      })
+      }])
       return this
     }
 
@@ -552,7 +573,12 @@ class Request extends EventEmitter {
     this.rowsAffected = 0
 
     if (typeof callback === 'function') {
-      this._execute(command, (err, recordsets, output, returnValue, rowsAffected, columns) => {
+      this._tracedCallback(CHANNELS.TRACE_EXECUTE, () => ({
+        procedure: command,
+        parameters: this._getParameterNames(),
+        requestId: IDS.get(this),
+        poolId: getPoolId(this)
+      }), this._execute, 1, [command, (err, recordsets, output, returnValue, rowsAffected, columns) => {
         if (this.stream) {
           if (err) this.emit('error', err)
           err = null
@@ -574,7 +600,7 @@ class Request extends EventEmitter {
         }
         if (this.arrayRowMode) result.columns = columns
         callback(null, result)
-      })
+      }])
       return this
     }
 

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -8,6 +8,7 @@ const globalConnection = require('../global-connection')
 const { RequestError, ConnectionError } = require('../error')
 const { TYPES } = require('../datatypes')
 const shared = require('../shared')
+const { CHANNELS, tracePromise, publish } = require('../diagnostics')
 
 /**
  * Class Request.
@@ -37,6 +38,7 @@ class Request extends EventEmitter {
 
     this.canceled = false
     this._paused = false
+    this._internal = false
     this.parent = parent || globalConnection.pool
     this.parameters = {}
     this.stream = null
@@ -218,6 +220,25 @@ class Request extends EventEmitter {
     return this.output(name, type, value)
   }
 
+  _getParameterNames () {
+    return Object.keys(this.parameters)
+  }
+
+  _getPoolId () {
+    let parent = this.parent
+    while (parent && !parent.pool) {
+      parent = parent.parent
+    }
+    return parent ? IDS.get(parent) : undefined
+  }
+
+  _tracedPromise (channel, contextFactory, fn) {
+    if (this._internal) {
+      return fn()
+    }
+    return tracePromise(channel, fn, contextFactory)
+  }
+
   /**
    * Execute the SQL batch.
    *
@@ -261,24 +282,31 @@ class Request extends EventEmitter {
       batch = this._template(strings, values)
     }
 
-    return new shared.Promise((resolve, reject) => {
-      this._batch(batch, (err, recordsets, output, rowsAffected) => {
-        if (this.stream) {
-          if (err) this.emit('error', err)
-          err = null
+    const batchCommand = batch
+    return this._tracedPromise(CHANNELS.TRACE_BATCH, () => ({
+      command: batchCommand,
+      requestId: IDS.get(this),
+      poolId: this._getPoolId()
+    }), () => {
+      return new shared.Promise((resolve, reject) => {
+        this._batch(batchCommand, (err, recordsets, output, rowsAffected) => {
+          if (this.stream) {
+            if (err) this.emit('error', err)
+            err = null
 
-          this.emit('done', {
+            this.emit('done', {
+              output,
+              rowsAffected
+            })
+          }
+
+          if (err) return reject(err)
+          resolve({
+            recordsets,
+            recordset: recordsets && recordsets[0],
             output,
             rowsAffected
           })
-        }
-
-        if (err) return reject(err)
-        resolve({
-          recordsets,
-          recordset: recordsets && recordsets[0],
-          output,
-          rowsAffected
         })
       })
     })
@@ -340,11 +368,18 @@ class Request extends EventEmitter {
       return this
     }
 
-    return new shared.Promise((resolve, reject) => {
-      this._bulk(table, options, (err, rowsAffected) => {
-        if (err) return reject(err)
-        resolve({
-          rowsAffected
+    return this._tracedPromise(CHANNELS.TRACE_BULK, () => ({
+      table: table.path || table.name,
+      rowCount: table.rows ? table.rows.length : 0,
+      requestId: IDS.get(this),
+      poolId: this._getPoolId()
+    }), () => {
+      return new shared.Promise((resolve, reject) => {
+        this._bulk(table, options, (err, rowsAffected) => {
+          if (err) return reject(err)
+          resolve({
+            rowsAffected
+          })
         })
       })
     })
@@ -460,27 +495,34 @@ class Request extends EventEmitter {
       command = this._template(strings, values)
     }
 
-    return new shared.Promise((resolve, reject) => {
-      this._query(command, (err, recordsets, output, rowsAffected, columns) => {
-        if (this.stream) {
-          if (err) this.emit('error', err)
-          err = null
+    return this._tracedPromise(CHANNELS.TRACE_QUERY, () => ({
+      command,
+      parameters: this._getParameterNames(),
+      requestId: IDS.get(this),
+      poolId: this._getPoolId()
+    }), () => {
+      return new shared.Promise((resolve, reject) => {
+        this._query(command, (err, recordsets, output, rowsAffected, columns) => {
+          if (this.stream) {
+            if (err) this.emit('error', err)
+            err = null
 
-          this.emit('done', {
+            this.emit('done', {
+              output,
+              rowsAffected
+            })
+          }
+
+          if (err) return reject(err)
+          const result = {
+            recordsets,
+            recordset: recordsets && recordsets[0],
             output,
             rowsAffected
-          })
-        }
-
-        if (err) return reject(err)
-        const result = {
-          recordsets,
-          recordset: recordsets && recordsets[0],
-          output,
-          rowsAffected
-        }
-        if (this.arrayRowMode) result.columns = columns
-        resolve(result)
+          }
+          if (this.arrayRowMode) result.columns = columns
+          resolve(result)
+        })
       })
     })
   }
@@ -544,29 +586,36 @@ class Request extends EventEmitter {
       return this
     }
 
-    return new shared.Promise((resolve, reject) => {
-      this._execute(command, (err, recordsets, output, returnValue, rowsAffected, columns) => {
-        if (this.stream) {
-          if (err) this.emit('error', err)
-          err = null
+    return this._tracedPromise(CHANNELS.TRACE_EXECUTE, () => ({
+      procedure: command,
+      parameters: this._getParameterNames(),
+      requestId: IDS.get(this),
+      poolId: this._getPoolId()
+    }), () => {
+      return new shared.Promise((resolve, reject) => {
+        this._execute(command, (err, recordsets, output, returnValue, rowsAffected, columns) => {
+          if (this.stream) {
+            if (err) this.emit('error', err)
+            err = null
 
-          this.emit('done', {
+            this.emit('done', {
+              output,
+              rowsAffected,
+              returnValue
+            })
+          }
+
+          if (err) return reject(err)
+          const result = {
+            recordsets,
+            recordset: recordsets && recordsets[0],
             output,
             rowsAffected,
             returnValue
-          })
-        }
-
-        if (err) return reject(err)
-        const result = {
-          recordsets,
-          recordset: recordsets && recordsets[0],
-          output,
-          rowsAffected,
-          returnValue
-        }
-        if (this.arrayRowMode) result.columns = columns
-        resolve(result)
+          }
+          if (this.arrayRowMode) result.columns = columns
+          resolve(result)
+        })
       })
     })
   }
@@ -598,6 +647,11 @@ class Request extends EventEmitter {
 
   cancel () {
     this._cancel()
+    if (!this._internal) {
+      publish(CHANNELS.REQUEST_CANCEL, () => ({
+        requestId: IDS.get(this)
+      }))
+    }
     return true
   }
 

--- a/lib/base/request.js
+++ b/lib/base/request.js
@@ -3,7 +3,7 @@
 const debug = require('debug')('mssql:base')
 const { EventEmitter } = require('node:events')
 const { Readable } = require('node:stream')
-const { IDS, objectHasProperty } = require('../utils')
+const { IDS, objectHasProperty, getPoolId } = require('../utils')
 const globalConnection = require('../global-connection')
 const { RequestError, ConnectionError } = require('../error')
 const { TYPES } = require('../datatypes')
@@ -224,14 +224,6 @@ class Request extends EventEmitter {
     return Object.keys(this.parameters)
   }
 
-  _getPoolId () {
-    let parent = this.parent
-    while (parent && !parent.pool) {
-      parent = parent.parent
-    }
-    return parent ? IDS.get(parent) : undefined
-  }
-
   _tracedPromise (channel, contextFactory, fn) {
     if (this._internal) {
       return fn()
@@ -286,7 +278,7 @@ class Request extends EventEmitter {
     return this._tracedPromise(CHANNELS.TRACE_BATCH, () => ({
       command: batchCommand,
       requestId: IDS.get(this),
-      poolId: this._getPoolId()
+      poolId: getPoolId(this)
     }), () => {
       return new shared.Promise((resolve, reject) => {
         this._batch(batchCommand, (err, recordsets, output, rowsAffected) => {
@@ -372,7 +364,7 @@ class Request extends EventEmitter {
       table: table.path || table.name,
       rowCount: table.rows ? table.rows.length : 0,
       requestId: IDS.get(this),
-      poolId: this._getPoolId()
+      poolId: getPoolId(this)
     }), () => {
       return new shared.Promise((resolve, reject) => {
         this._bulk(table, options, (err, rowsAffected) => {
@@ -499,7 +491,7 @@ class Request extends EventEmitter {
       command,
       parameters: this._getParameterNames(),
       requestId: IDS.get(this),
-      poolId: this._getPoolId()
+      poolId: getPoolId(this)
     }), () => {
       return new shared.Promise((resolve, reject) => {
         this._query(command, (err, recordsets, output, rowsAffected, columns) => {
@@ -590,7 +582,7 @@ class Request extends EventEmitter {
       procedure: command,
       parameters: this._getParameterNames(),
       requestId: IDS.get(this),
-      poolId: this._getPoolId()
+      poolId: getPoolId(this)
     }), () => {
       return new shared.Promise((resolve, reject) => {
         this._execute(command, (err, recordsets, output, returnValue, rowsAffected, columns) => {

--- a/lib/base/transaction.js
+++ b/lib/base/transaction.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('mssql:base')
 const { EventEmitter } = require('node:events')
-const { IDS } = require('../utils')
+const { IDS, getPoolId } = require('../utils')
 const globalConnection = require('../global-connection')
 const { TransactionError } = require('../error')
 const shared = require('../shared')
@@ -101,14 +101,6 @@ class Transaction extends EventEmitter {
     return 'UNKNOWN'
   }
 
-  _getPoolId () {
-    let parent = this.parent
-    while (parent && !parent.pool) {
-      parent = parent.parent
-    }
-    return parent ? IDS.get(parent) : undefined
-  }
-
   begin (isolationLevel, callback) {
     if (isolationLevel instanceof Function) {
       callback = isolationLevel
@@ -121,7 +113,7 @@ class Transaction extends EventEmitter {
           publish(CHANNELS.TRANSACTION_BEGIN, () => ({
             transactionId: IDS.get(this),
             isolationLevel: this._getIsolationLevelName(),
-            poolId: this._getPoolId()
+            poolId: getPoolId(this)
           }))
           this.emit('begin')
         }
@@ -136,7 +128,7 @@ class Transaction extends EventEmitter {
         publish(CHANNELS.TRANSACTION_BEGIN, () => ({
           transactionId: IDS.get(this),
           isolationLevel: this._getIsolationLevelName(),
-          poolId: this._getPoolId()
+          poolId: getPoolId(this)
         }))
         this.emit('begin')
         resolve(this)

--- a/lib/base/transaction.js
+++ b/lib/base/transaction.js
@@ -9,6 +9,10 @@ const shared = require('../shared')
 const ISOLATION_LEVEL = require('../isolationlevel')
 const { CHANNELS, publish } = require('../diagnostics')
 
+const ISOLATION_LEVEL_NAMES = Object.fromEntries(
+  Object.entries(ISOLATION_LEVEL).map(([name, value]) => [value, name])
+)
+
 /**
  * Class Transaction.
  *
@@ -93,14 +97,6 @@ class Transaction extends EventEmitter {
    * @return {Transaction|Promise}
    */
 
-  _getIsolationLevelName () {
-    const levels = Object.entries(ISOLATION_LEVEL)
-    for (const [name, value] of levels) {
-      if (value === this.isolationLevel) return name
-    }
-    return 'UNKNOWN'
-  }
-
   begin (isolationLevel, callback) {
     if (isolationLevel instanceof Function) {
       callback = isolationLevel
@@ -112,7 +108,8 @@ class Transaction extends EventEmitter {
         if (!err) {
           publish(CHANNELS.TRANSACTION_BEGIN, () => ({
             transactionId: IDS.get(this),
-            isolationLevel: this._getIsolationLevelName(),
+            isolationLevel: this.isolationLevel,
+            isolationLevelName: ISOLATION_LEVEL_NAMES[this.isolationLevel],
             poolId: getPoolId(this)
           }))
           this.emit('begin')
@@ -127,7 +124,8 @@ class Transaction extends EventEmitter {
         if (err) return reject(err)
         publish(CHANNELS.TRANSACTION_BEGIN, () => ({
           transactionId: IDS.get(this),
-          isolationLevel: this._getIsolationLevelName(),
+          isolationLevel: this.isolationLevel,
+          isolationLevelName: ISOLATION_LEVEL_NAMES[this.isolationLevel],
           poolId: getPoolId(this)
         }))
         this.emit('begin')

--- a/lib/base/transaction.js
+++ b/lib/base/transaction.js
@@ -7,6 +7,7 @@ const globalConnection = require('../global-connection')
 const { TransactionError } = require('../error')
 const shared = require('../shared')
 const ISOLATION_LEVEL = require('../isolationlevel')
+const { CHANNELS, publish } = require('../diagnostics')
 
 /**
  * Class Transaction.
@@ -92,6 +93,22 @@ class Transaction extends EventEmitter {
    * @return {Transaction|Promise}
    */
 
+  _getIsolationLevelName () {
+    const levels = Object.entries(ISOLATION_LEVEL)
+    for (const [name, value] of levels) {
+      if (value === this.isolationLevel) return name
+    }
+    return 'UNKNOWN'
+  }
+
+  _getPoolId () {
+    let parent = this.parent
+    while (parent && !parent.pool) {
+      parent = parent.parent
+    }
+    return parent ? IDS.get(parent) : undefined
+  }
+
   begin (isolationLevel, callback) {
     if (isolationLevel instanceof Function) {
       callback = isolationLevel
@@ -101,6 +118,11 @@ class Transaction extends EventEmitter {
     if (typeof callback === 'function') {
       this._begin(isolationLevel, err => {
         if (!err) {
+          publish(CHANNELS.TRANSACTION_BEGIN, () => ({
+            transactionId: IDS.get(this),
+            isolationLevel: this._getIsolationLevelName(),
+            poolId: this._getPoolId()
+          }))
           this.emit('begin')
         }
         callback(err)
@@ -111,6 +133,11 @@ class Transaction extends EventEmitter {
     return new shared.Promise((resolve, reject) => {
       this._begin(isolationLevel, err => {
         if (err) return reject(err)
+        publish(CHANNELS.TRANSACTION_BEGIN, () => ({
+          transactionId: IDS.get(this),
+          isolationLevel: this._getIsolationLevelName(),
+          poolId: this._getPoolId()
+        }))
         this.emit('begin')
         resolve(this)
       })
@@ -155,6 +182,9 @@ class Transaction extends EventEmitter {
     if (typeof callback === 'function') {
       this._commit(err => {
         if (!err) {
+          publish(CHANNELS.TRANSACTION_COMMIT, () => ({
+            transactionId: IDS.get(this)
+          }))
           this.emit('commit')
         }
         callback(err)
@@ -165,6 +195,9 @@ class Transaction extends EventEmitter {
     return new shared.Promise((resolve, reject) => {
       this._commit(err => {
         if (err) return reject(err)
+        publish(CHANNELS.TRANSACTION_COMMIT, () => ({
+          transactionId: IDS.get(this)
+        }))
         this.emit('commit')
         resolve()
       })
@@ -214,6 +247,10 @@ class Transaction extends EventEmitter {
     if (typeof callback === 'function') {
       this._rollback(err => {
         if (!err) {
+          publish(CHANNELS.TRANSACTION_ROLLBACK, () => ({
+            transactionId: IDS.get(this),
+            aborted: this._aborted
+          }))
           this.emit('rollback', this._aborted)
         }
         callback(err)
@@ -224,6 +261,10 @@ class Transaction extends EventEmitter {
     return new shared.Promise((resolve, reject) => {
       return this._rollback(err => {
         if (err) return reject(err)
+        publish(CHANNELS.TRANSACTION_ROLLBACK, () => ({
+          transactionId: IDS.get(this),
+          aborted: this._aborted
+        }))
         this.emit('rollback', this._aborted)
         resolve()
       })

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -9,8 +9,8 @@ const TRACE_EXECUTE = 'mssql:execute'
 const TRACE_BULK = 'mssql:bulk'
 const TRACE_CONNECT = 'mssql:connect'
 const TRACE_POOL_ACQUIRE = 'mssql:pool:acquire'
-const TRACE_PREPARE = 'mssql:prepare'
-const TRACE_PREPARED_EXECUTE = 'mssql:prepared-execute'
+const TRACE_PREPARED_STATEMENT_PREPARE = 'mssql:prepared-statement:prepare'
+const TRACE_PREPARED_STATEMENT_EXECUTE = 'mssql:prepared-statement:execute'
 
 // Point-event channel names
 const CONNECTION_ACQUIRE = 'mssql:connection:acquire'
@@ -31,8 +31,8 @@ const CHANNELS = Object.freeze({
   TRACE_BULK,
   TRACE_CONNECT,
   TRACE_POOL_ACQUIRE,
-  TRACE_PREPARE,
-  TRACE_PREPARED_EXECUTE,
+  TRACE_PREPARED_STATEMENT_PREPARE,
+  TRACE_PREPARED_STATEMENT_EXECUTE,
   CONNECTION_ACQUIRE,
   CONNECTION_RELEASE,
   CONNECTION_CREATE,
@@ -53,8 +53,8 @@ const tracingChannels = {
   [TRACE_BULK]: dc.tracingChannel(TRACE_BULK),
   [TRACE_CONNECT]: dc.tracingChannel(TRACE_CONNECT),
   [TRACE_POOL_ACQUIRE]: dc.tracingChannel(TRACE_POOL_ACQUIRE),
-  [TRACE_PREPARE]: dc.tracingChannel(TRACE_PREPARE),
-  [TRACE_PREPARED_EXECUTE]: dc.tracingChannel(TRACE_PREPARED_EXECUTE)
+  [TRACE_PREPARED_STATEMENT_PREPARE]: dc.tracingChannel(TRACE_PREPARED_STATEMENT_PREPARE),
+  [TRACE_PREPARED_STATEMENT_EXECUTE]: dc.tracingChannel(TRACE_PREPARED_STATEMENT_EXECUTE)
 }
 
 // Pre-create point-event channel instances at module load time

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -1,0 +1,134 @@
+'use strict'
+
+const dc = require('node:diagnostics_channel')
+
+// TracingChannel names
+const TRACE_QUERY = 'mssql:query'
+const TRACE_BATCH = 'mssql:batch'
+const TRACE_EXECUTE = 'mssql:execute'
+const TRACE_BULK = 'mssql:bulk'
+const TRACE_CONNECT = 'mssql:connect'
+const TRACE_POOL_ACQUIRE = 'mssql:pool:acquire'
+const TRACE_PREPARE = 'mssql:prepare'
+const TRACE_PREPARED_EXECUTE = 'mssql:prepared-execute'
+
+// Point-event channel names
+const CONNECTION_ACQUIRE = 'mssql:connection:acquire'
+const CONNECTION_RELEASE = 'mssql:connection:release'
+const CONNECTION_CREATE = 'mssql:connection:create'
+const CONNECTION_DESTROY = 'mssql:connection:destroy'
+const POOL_CLOSE = 'mssql:pool:close'
+const TRANSACTION_BEGIN = 'mssql:transaction:begin'
+const TRANSACTION_COMMIT = 'mssql:transaction:commit'
+const TRANSACTION_ROLLBACK = 'mssql:transaction:rollback'
+const REQUEST_CANCEL = 'mssql:request:cancel'
+const PREPARED_STATEMENT_UNPREPARE = 'mssql:prepared-statement:unprepare'
+
+const CHANNELS = Object.freeze({
+  TRACE_QUERY,
+  TRACE_BATCH,
+  TRACE_EXECUTE,
+  TRACE_BULK,
+  TRACE_CONNECT,
+  TRACE_POOL_ACQUIRE,
+  TRACE_PREPARE,
+  TRACE_PREPARED_EXECUTE,
+  CONNECTION_ACQUIRE,
+  CONNECTION_RELEASE,
+  CONNECTION_CREATE,
+  CONNECTION_DESTROY,
+  POOL_CLOSE,
+  TRANSACTION_BEGIN,
+  TRANSACTION_COMMIT,
+  TRANSACTION_ROLLBACK,
+  REQUEST_CANCEL,
+  PREPARED_STATEMENT_UNPREPARE
+})
+
+// Pre-create TracingChannel instances at module load time
+const tracingChannels = {
+  [TRACE_QUERY]: dc.tracingChannel(TRACE_QUERY),
+  [TRACE_BATCH]: dc.tracingChannel(TRACE_BATCH),
+  [TRACE_EXECUTE]: dc.tracingChannel(TRACE_EXECUTE),
+  [TRACE_BULK]: dc.tracingChannel(TRACE_BULK),
+  [TRACE_CONNECT]: dc.tracingChannel(TRACE_CONNECT),
+  [TRACE_POOL_ACQUIRE]: dc.tracingChannel(TRACE_POOL_ACQUIRE),
+  [TRACE_PREPARE]: dc.tracingChannel(TRACE_PREPARE),
+  [TRACE_PREPARED_EXECUTE]: dc.tracingChannel(TRACE_PREPARED_EXECUTE)
+}
+
+// Pre-create point-event channel instances at module load time
+const pointChannels = {
+  [CONNECTION_ACQUIRE]: dc.channel(CONNECTION_ACQUIRE),
+  [CONNECTION_RELEASE]: dc.channel(CONNECTION_RELEASE),
+  [CONNECTION_CREATE]: dc.channel(CONNECTION_CREATE),
+  [CONNECTION_DESTROY]: dc.channel(CONNECTION_DESTROY),
+  [POOL_CLOSE]: dc.channel(POOL_CLOSE),
+  [TRANSACTION_BEGIN]: dc.channel(TRANSACTION_BEGIN),
+  [TRANSACTION_COMMIT]: dc.channel(TRANSACTION_COMMIT),
+  [TRANSACTION_ROLLBACK]: dc.channel(TRANSACTION_ROLLBACK),
+  [REQUEST_CANCEL]: dc.channel(REQUEST_CANCEL),
+  [PREPARED_STATEMENT_UNPREPARE]: dc.channel(PREPARED_STATEMENT_UNPREPARE)
+}
+
+/**
+ * Trace an async operation using a TracingChannel.
+ *
+ * When subscribers are active, wraps `fn` with TracingChannel.tracePromise()
+ * for promise-returning functions, or TracingChannel.traceCallback() for
+ * callback-based functions. When no subscribers are active, calls `fn` directly.
+ *
+ * @param {string} name - TracingChannel name (one of CHANNELS.TRACE_*)
+ * @param {Function} fn - The function to trace
+ * @param {object} context - Context object passed to subscribers
+ * @returns {*} The return value of fn
+ */
+function tracePromise (name, fn, context) {
+  const channel = tracingChannels[name]
+  if (channel.hasSubscribers) {
+    return channel.tracePromise(fn, context)
+  }
+  return fn()
+}
+
+/**
+ * Trace a callback-based async operation using a TracingChannel.
+ *
+ * @param {string} name - TracingChannel name (one of CHANNELS.TRACE_*)
+ * @param {Function} fn - The callback-receiving function to trace
+ * @param {number} position - Zero-indexed argument position of the callback
+ * @param {object} context - Context object passed to subscribers
+ * @param {*} thisArg - The receiver for the function call
+ * @param {...*} args - Arguments to pass to the function
+ * @returns {*} The return value of fn
+ */
+function traceCallback (name, fn, position, context, thisArg, ...args) {
+  const channel = tracingChannels[name]
+  if (channel.hasSubscribers) {
+    return channel.traceCallback(fn, position, context, thisArg, ...args)
+  }
+  return fn.call(thisArg, ...args)
+}
+
+/**
+ * Publish a point event on a named channel.
+ *
+ * Only allocates the message object when subscribers are active.
+ *
+ * @param {string} name - Point-event channel name (one of CHANNELS.*)
+ * @param {Function} factory - Factory function that returns the message object
+ */
+function publish (name, factory) {
+  const channel = pointChannels[name]
+  if (channel.hasSubscribers) {
+    channel.publish(factory())
+  }
+}
+
+module.exports = {
+  CHANNELS,
+  tracingChannels,
+  tracePromise,
+  traceCallback,
+  publish
+}

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -106,6 +106,30 @@ function tracePromise (name, fn, contextFactory) {
 }
 
 /**
+ * Trace a callback-style async operation using a TracingChannel.
+ *
+ * When subscribers are active, delegates to TracingChannel.traceCallback,
+ * which replaces the callback at `position` in `args` with a wrapped
+ * version that publishes to start/end/asyncStart/asyncEnd/error. When
+ * no subscribers are active, calls `fn` directly with zero overhead.
+ *
+ * @param {string} name - TracingChannel name (one of CHANNELS.TRACE_*)
+ * @param {Function} fn - The function to call (receives callback at `position`)
+ * @param {number} position - Index of the callback within `args`
+ * @param {Function} contextFactory - Factory function returning the context object
+ * @param {*} thisArg - `this` binding for fn
+ * @param {Array} args - Arguments to pass to fn (includes the callback at `position`)
+ * @returns {*} The return value of fn
+ */
+function traceCallback (name, fn, position, contextFactory, thisArg, args) {
+  const channel = tracingChannels[name]
+  if (tracingChannelHasSubscribers(channel)) {
+    return channel.traceCallback(fn, position, contextFactory(), thisArg, ...args)
+  }
+  return fn.apply(thisArg, args)
+}
+
+/**
  * Publish a point event on a named channel.
  *
  * Only allocates the message object when subscribers are active.
@@ -124,5 +148,6 @@ module.exports = {
   CHANNELS,
   tracingChannels,
   tracePromise,
+  traceCallback,
   publish
 }

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -75,18 +75,19 @@ const pointChannels = {
  * Trace an async operation using a TracingChannel.
  *
  * When subscribers are active, wraps `fn` with TracingChannel.tracePromise()
- * for promise-returning functions, or TracingChannel.traceCallback() for
- * callback-based functions. When no subscribers are active, calls `fn` directly.
+ * for promise-returning functions. When no subscribers are active, calls `fn`
+ * directly with zero overhead (no context allocation).
  *
  * @param {string} name - TracingChannel name (one of CHANNELS.TRACE_*)
- * @param {Function} fn - The function to trace
- * @param {object} context - Context object passed to subscribers
- * @returns {*} The return value of fn
+ * @param {Function} fn - The function to trace (must return a Promise)
+ * @param {Function|object} context - Context object or factory function returning one
+ * @returns {Promise} The return value of fn
  */
 function tracePromise (name, fn, context) {
   const channel = tracingChannels[name]
   if (channel.hasSubscribers) {
-    return channel.tracePromise(fn, context)
+    const ctx = typeof context === 'function' ? context() : context
+    return channel.tracePromise(fn, ctx)
   }
   return fn()
 }

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -71,44 +71,38 @@ const pointChannels = {
   [PREPARED_STATEMENT_UNPREPARE]: dc.channel(PREPARED_STATEMENT_UNPREPARE)
 }
 
-/**
- * Trace an async operation using a TracingChannel.
- *
- * When subscribers are active, wraps `fn` with TracingChannel.tracePromise()
- * for promise-returning functions. When no subscribers are active, calls `fn`
- * directly with zero overhead (no context allocation).
- *
- * @param {string} name - TracingChannel name (one of CHANNELS.TRACE_*)
- * @param {Function} fn - The function to trace (must return a Promise)
- * @param {Function|object} context - Context object or factory function returning one
- * @returns {Promise} The return value of fn
- */
-function tracePromise (name, fn, context) {
-  const channel = tracingChannels[name]
-  if (channel.hasSubscribers) {
-    const ctx = typeof context === 'function' ? context() : context
-    return channel.tracePromise(fn, ctx)
-  }
-  return fn()
+// TracingChannel.hasSubscribers was added in Node 22. On 18.19 / 20 the
+// aggregate property is undefined, so we fall back to checking the
+// sub-channels directly (these have existed since the original
+// diagnostics_channel API). Preserves the zero-cost fast path across all
+// supported runtimes.
+function tracingChannelHasSubscribers (tc) {
+  if (typeof tc.hasSubscribers === 'boolean') return tc.hasSubscribers
+  return tc.start.hasSubscribers ||
+    tc.end.hasSubscribers ||
+    tc.asyncStart.hasSubscribers ||
+    tc.asyncEnd.hasSubscribers ||
+    tc.error.hasSubscribers
 }
 
 /**
- * Trace a callback-based async operation using a TracingChannel.
+ * Trace an async operation using a TracingChannel.
+ *
+ * When subscribers are active, wraps `fn` with TracingChannel.tracePromise().
+ * When no subscribers are active, calls `fn` directly with zero overhead
+ * (no context allocation).
  *
  * @param {string} name - TracingChannel name (one of CHANNELS.TRACE_*)
- * @param {Function} fn - The callback-receiving function to trace
- * @param {number} position - Zero-indexed argument position of the callback
- * @param {object} context - Context object passed to subscribers
- * @param {*} thisArg - The receiver for the function call
- * @param {...*} args - Arguments to pass to the function
- * @returns {*} The return value of fn
+ * @param {Function} fn - The function to trace (must return a Promise)
+ * @param {Function} contextFactory - Factory function returning the context object
+ * @returns {Promise} The return value of fn
  */
-function traceCallback (name, fn, position, context, thisArg, ...args) {
+function tracePromise (name, fn, contextFactory) {
   const channel = tracingChannels[name]
-  if (channel.hasSubscribers) {
-    return channel.traceCallback(fn, position, context, thisArg, ...args)
+  if (tracingChannelHasSubscribers(channel)) {
+    return channel.tracePromise(fn, contextFactory())
   }
-  return fn.call(thisArg, ...args)
+  return fn()
 }
 
 /**
@@ -130,6 +124,5 @@ module.exports = {
   CHANNELS,
   tracingChannels,
   tracePromise,
-  traceCallback,
   publish
 }

--- a/lib/msnodesqlv8/connection-pool.js
+++ b/lib/msnodesqlv8/connection-pool.js
@@ -8,6 +8,7 @@ const shared = require('../shared')
 const ConnectionError = require('../error/connection-error')
 const { platform } = require('node:os')
 const { build } = require('@tediousjs/connection-string')
+const { CHANNELS, publish } = require('../diagnostics')
 
 const DEFAULT_CONNECTION_DRIVER = ['darwin', 'linux'].includes(platform()) ? 'ODBC Driver 17 for SQL Server' : 'SQL Server Native Client 11.0'
 
@@ -58,6 +59,12 @@ class ConnectionPool extends BaseConnectionPool {
         IDS.add(tds, 'Connection', connedtionId)
         tds.setUseUTC(this.config.options.useUTC)
         debug('connection(%d): established', IDS.get(tds))
+        publish(CHANNELS.CONNECTION_CREATE, () => ({
+          connectionId: IDS.get(tds),
+          poolId: IDS.get(this),
+          server: this.config.server,
+          database: this.config.database
+        }))
         resolve(tds)
       })
     })
@@ -80,9 +87,15 @@ class ConnectionPool extends BaseConnectionPool {
         resolve()
         return
       }
-      debug('connection(%d): destroying', IDS.get(tds))
+      const connectionId = IDS.get(tds)
+      const poolId = IDS.get(this)
+      debug('connection(%d): destroying', connectionId)
       tds.close(() => {
-        debug('connection(%d): destroyed', IDS.get(tds))
+        debug('connection(%d): destroyed', connectionId)
+        publish(CHANNELS.CONNECTION_DESTROY, () => ({
+          connectionId,
+          poolId
+        }))
         resolve()
       })
     })

--- a/lib/tedious/connection-pool.js
+++ b/lib/tedious/connection-pool.js
@@ -6,6 +6,7 @@ const BaseConnectionPool = require('../base/connection-pool')
 const { IDS } = require('../utils')
 const shared = require('../shared')
 const ConnectionError = require('../error/connection-error')
+const { CHANNELS, publish } = require('../diagnostics')
 
 class ConnectionPool extends BaseConnectionPool {
   _config () {
@@ -88,6 +89,12 @@ class ConnectionPool extends BaseConnectionPool {
 
         debug('connection(%d): established', IDS.get(tedious))
         this.collation = tedious.databaseCollation
+        publish(CHANNELS.CONNECTION_CREATE, () => ({
+          connectionId: IDS.get(tedious),
+          poolId: IDS.get(this),
+          server: this.config.server,
+          database: this.config.database
+        }))
         resolveOnce(tedious)
       })
       IDS.add(tedious, 'Connection')
@@ -156,13 +163,23 @@ class ConnectionPool extends BaseConnectionPool {
         return
       }
       debug('connection(%d): destroying', IDS.get(tedious))
+      const connectionId = IDS.get(tedious)
+      const poolId = IDS.get(this)
 
       if (tedious.closed) {
         debug('connection(%d): already closed', IDS.get(tedious))
+        publish(CHANNELS.CONNECTION_DESTROY, () => ({
+          connectionId,
+          poolId
+        }))
         resolve()
       } else {
         tedious.once('end', () => {
           debug('connection(%d): destroyed', IDS.get(tedious))
+          publish(CHANNELS.CONNECTION_DESTROY, () => ({
+            connectionId,
+            poolId
+          }))
           resolve()
         })
 

--- a/lib/tedious/connection-pool.js
+++ b/lib/tedious/connection-pool.js
@@ -168,10 +168,6 @@ class ConnectionPool extends BaseConnectionPool {
 
       if (tedious.closed) {
         debug('connection(%d): already closed', IDS.get(tedious))
-        publish(CHANNELS.CONNECTION_DESTROY, () => ({
-          connectionId,
-          poolId
-        }))
         resolve()
       } else {
         tedious.once('end', () => {

--- a/lib/tedious/transaction.js
+++ b/lib/tedious/transaction.js
@@ -4,6 +4,7 @@ const debug = require('debug')('mssql:tedi')
 const BaseTransaction = require('../base/transaction')
 const { IDS } = require('../utils')
 const TransactionError = require('../error/transaction-error')
+const { CHANNELS, publish } = require('../diagnostics')
 
 class Transaction extends BaseTransaction {
   constructor (parent) {
@@ -23,6 +24,10 @@ class Transaction extends BaseTransaction {
         this._acquiredConfig = null
         this._aborted = true
 
+        publish(CHANNELS.TRANSACTION_ROLLBACK, () => ({
+          transactionId: IDS.get(this),
+          aborted: true
+        }))
         this.emit('rollback', true)
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,14 @@ const INCREMENT = {
   PreparedStatement: 1
 }
 
+const getPoolId = (obj) => {
+  let parent = obj && obj.parent
+  while (parent && !parent.pool) {
+    parent = parent.parent
+  }
+  return parent ? IDS.get(parent) : undefined
+}
+
 module.exports = {
   objectHasProperty: (object, property) => Object.prototype.hasOwnProperty.call(object, property),
   INCREMENT,
@@ -18,5 +26,6 @@ module.exports = {
       if (id) return IDS.set(object, id)
       IDS.set(object, INCREMENT[type]++)
     }
-  }
+  },
+  getPoolId
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "standard": "^17.0.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18.19.0"
   },
   "files": [
     "lib/",

--- a/test/common/diagnostics.js
+++ b/test/common/diagnostics.js
@@ -371,4 +371,117 @@ describe('Diagnostics Channel', () => {
       }
     })
   })
+
+  // Exercise the callback API through TracingChannel#traceCallback, which
+  // shares the sub-event channels (start/asyncEnd/error/...) with
+  // tracePromise — subscribers should not need to branch by API style.
+  describe('Callback API tracing', () => {
+    const sql = require('../../')
+
+    function collectTraces (tracingChannel) {
+      const events = []
+      const handlers = {
+        start: (ctx) => events.push({ event: 'start', ctx }),
+        end: (ctx) => events.push({ event: 'end', ctx }),
+        asyncStart: (ctx) => events.push({ event: 'asyncStart', ctx }),
+        asyncEnd: (ctx) => events.push({ event: 'asyncEnd', ctx }),
+        error: (ctx) => events.push({ event: 'error', ctx })
+      }
+      tracingChannel.subscribe(handlers)
+      return {
+        events,
+        stop () { tracingChannel.unsubscribe(handlers) }
+      }
+    }
+
+    it('request.query(cb) emits TRACE_QUERY start/asyncEnd with context', (done) => {
+      const req = new sql.Request()
+      req._query = (cmd, cb) => setImmediate(cb, null, [[{ x: 1 }]], {}, 1)
+      req.input('id', sql.Int, 42)
+
+      const tc = tracingChannels[CHANNELS.TRACE_QUERY]
+      const { events, stop } = collectTraces(tc)
+      req.query('SELECT @id', (err, result) => {
+        assert.ifError(err)
+        assert.ok(result)
+        // asyncEnd fires after this callback returns, so defer the check.
+        setImmediate(() => {
+          try {
+            const starts = events.filter(e => e.event === 'start')
+            const asyncEnds = events.filter(e => e.event === 'asyncEnd')
+            assert.strictEqual(starts.length, 1)
+            assert.strictEqual(asyncEnds.length, 1)
+            assert.strictEqual(starts[0].ctx.command, 'SELECT @id')
+            assert.deepStrictEqual(starts[0].ctx.parameters, ['id'])
+            done()
+          } catch (e) {
+            done(e)
+          } finally {
+            stop()
+          }
+        })
+      })
+    })
+
+    it('request.query(cb) emits TRACE_QUERY error on driver failure', (done) => {
+      const req = new sql.Request()
+      const boom = new Error('boom')
+      req._query = (cmd, cb) => setImmediate(cb, boom)
+
+      const tc = tracingChannels[CHANNELS.TRACE_QUERY]
+      const { events, stop } = collectTraces(tc)
+      req.query('SELECT 1', (err) => {
+        try {
+          assert.strictEqual(err, boom)
+          const errors = events.filter(e => e.event === 'error')
+          assert.strictEqual(errors.length, 1)
+          assert.strictEqual(errors[0].ctx.error, boom)
+          done()
+        } catch (e) {
+          done(e)
+        } finally {
+          stop()
+        }
+      })
+    })
+
+    it('callback path honours the _internal flag', (done) => {
+      const req = new sql.Request()
+      req._internal = true
+      req._query = (cmd, cb) => setImmediate(cb, null, [[]], {}, 0)
+
+      const tc = tracingChannels[CHANNELS.TRACE_QUERY]
+      const { events, stop } = collectTraces(tc)
+      req.query('SELECT 1', () => {
+        try {
+          assert.strictEqual(events.length, 0)
+          done()
+        } catch (e) {
+          done(e)
+        } finally {
+          stop()
+        }
+      })
+    })
+
+    it('request.execute(cb) emits TRACE_EXECUTE', (done) => {
+      const req = new sql.Request()
+      req._execute = (cmd, cb) => setImmediate(cb, null, [[]], {}, 0, 0)
+
+      const tc = tracingChannels[CHANNELS.TRACE_EXECUTE]
+      const { events, stop } = collectTraces(tc)
+      req.execute('sp_test', () => {
+        try {
+          const starts = events.filter(e => e.event === 'start')
+          assert.strictEqual(starts.length, 1)
+          assert.strictEqual(starts[0].ctx.procedure, 'sp_test')
+          done()
+        } catch (e) {
+          done(e)
+        } finally {
+          stop()
+        }
+      })
+    })
+  })
 })

--- a/test/common/diagnostics.js
+++ b/test/common/diagnostics.js
@@ -192,4 +192,183 @@ describe('Diagnostics Channel', () => {
       assert.strictEqual(req._internal, false)
     })
   })
+
+  // Integration tests: drive the real Request / Transaction / ConnectionPool
+  // classes (with stubbed drivers) to verify the diagnostics_channel
+  // instrumentation fires end-to-end — not just that the helpers work.
+  describe('Instrumentation integration', () => {
+    const sql = require('../../')
+
+    function collect (channel) {
+      const events = []
+      const handler = (msg) => events.push(msg)
+      dc.subscribe(channel, handler)
+      return {
+        events,
+        stop () { dc.unsubscribe(channel, handler) }
+      }
+    }
+
+    function collectTraces (tracingChannel) {
+      const events = []
+      const handlers = {
+        start: (ctx) => events.push({ event: 'start', ctx }),
+        end: (ctx) => events.push({ event: 'end', ctx }),
+        asyncStart: (ctx) => events.push({ event: 'asyncStart', ctx }),
+        asyncEnd: (ctx) => events.push({ event: 'asyncEnd', ctx }),
+        error: (ctx) => events.push({ event: 'error', ctx })
+      }
+      tracingChannel.subscribe(handlers)
+      return {
+        events,
+        stop () { tracingChannel.unsubscribe(handlers) }
+      }
+    }
+
+    it('request.query() emits TRACE_QUERY start/asyncEnd with context', async () => {
+      const req = new sql.Request()
+      req._query = (cmd, cb) => setImmediate(cb, null, [[{ x: 1 }]], {}, 1)
+      req.input('id', sql.Int, 42)
+
+      const tc = tracingChannels[CHANNELS.TRACE_QUERY]
+      const { events, stop } = collectTraces(tc)
+      try {
+        await req.query('SELECT @id')
+        const starts = events.filter(e => e.event === 'start')
+        const asyncEnds = events.filter(e => e.event === 'asyncEnd')
+        assert.strictEqual(starts.length, 1)
+        assert.strictEqual(asyncEnds.length, 1)
+        assert.strictEqual(starts[0].ctx.command, 'SELECT @id')
+        assert.deepStrictEqual(starts[0].ctx.parameters, ['id'])
+        assert.strictEqual(typeof starts[0].ctx.requestId, 'number')
+      } finally {
+        stop()
+      }
+    })
+
+    it('request.query() emits TRACE_QUERY error on rejection', async () => {
+      const req = new sql.Request()
+      const boom = new Error('boom')
+      req._query = (cmd, cb) => setImmediate(cb, boom)
+
+      const tc = tracingChannels[CHANNELS.TRACE_QUERY]
+      const { events, stop } = collectTraces(tc)
+      try {
+        await assert.rejects(() => req.query('SELECT 1'), { message: 'boom' })
+        const errors = events.filter(e => e.event === 'error')
+        assert.strictEqual(errors.length, 1)
+        assert.strictEqual(errors[0].ctx.error, boom)
+      } finally {
+        stop()
+      }
+    })
+
+    it('request marked as _internal does not emit TRACE_QUERY', async () => {
+      const req = new sql.Request()
+      req._internal = true
+      req._query = (cmd, cb) => setImmediate(cb, null, [[]], {}, 0)
+
+      const tc = tracingChannels[CHANNELS.TRACE_QUERY]
+      const { events, stop } = collectTraces(tc)
+      try {
+        await req.query('SELECT 1')
+        assert.strictEqual(events.length, 0)
+      } finally {
+        stop()
+      }
+    })
+
+    it('request.execute() emits TRACE_EXECUTE with procedure name', async () => {
+      const req = new sql.Request()
+      req._execute = (cmd, cb) => setImmediate(cb, null, [[]], {}, 0, 0)
+
+      const tc = tracingChannels[CHANNELS.TRACE_EXECUTE]
+      const { events, stop } = collectTraces(tc)
+      try {
+        await req.execute('sp_test')
+        const starts = events.filter(e => e.event === 'start')
+        assert.strictEqual(starts.length, 1)
+        assert.strictEqual(starts[0].ctx.procedure, 'sp_test')
+      } finally {
+        stop()
+      }
+    })
+
+    it('request.cancel() emits REQUEST_CANCEL for user requests only', () => {
+      const { events, stop } = collect(CHANNELS.REQUEST_CANCEL)
+      try {
+        const userReq = new sql.Request()
+        userReq._cancel = () => {}
+        userReq.cancel()
+        assert.strictEqual(events.length, 1)
+        assert.strictEqual(typeof events[0].requestId, 'number')
+
+        const internalReq = new sql.Request()
+        internalReq._internal = true
+        internalReq._cancel = () => {}
+        internalReq.cancel()
+        assert.strictEqual(events.length, 1, 'internal cancel should not emit')
+      } finally {
+        stop()
+      }
+    })
+
+    // Stub for Transaction._begin that mirrors what the real driver does:
+    // assigns the requested isolation level and clears the aborted flag.
+    function stubTransaction (tx) {
+      tx._begin = function (level, cb) {
+        if (level) this.isolationLevel = level
+        this._aborted = false
+        setImmediate(cb, null)
+      }
+      tx._commit = (cb) => setImmediate(cb, null)
+      tx._rollback = (cb) => setImmediate(cb, null)
+    }
+
+    it('transaction.begin emits TRANSACTION_BEGIN with numeric + named isolation level', async () => {
+      const tx = new sql.Transaction()
+      stubTransaction(tx)
+
+      const { events, stop } = collect(CHANNELS.TRANSACTION_BEGIN)
+      try {
+        await tx.begin(sql.ISOLATION_LEVEL.SERIALIZABLE)
+        assert.strictEqual(events.length, 1)
+        assert.strictEqual(events[0].isolationLevel, sql.ISOLATION_LEVEL.SERIALIZABLE)
+        assert.strictEqual(events[0].isolationLevelName, 'SERIALIZABLE')
+        assert.strictEqual(typeof events[0].transactionId, 'number')
+      } finally {
+        stop()
+      }
+    })
+
+    it('transaction.commit emits TRANSACTION_COMMIT', async () => {
+      const tx = new sql.Transaction()
+      stubTransaction(tx)
+
+      await tx.begin()
+      const { events, stop } = collect(CHANNELS.TRANSACTION_COMMIT)
+      try {
+        await tx.commit()
+        assert.strictEqual(events.length, 1)
+        assert.strictEqual(typeof events[0].transactionId, 'number')
+      } finally {
+        stop()
+      }
+    })
+
+    it('transaction.rollback emits TRANSACTION_ROLLBACK with aborted flag', async () => {
+      const tx = new sql.Transaction()
+      stubTransaction(tx)
+
+      await tx.begin()
+      const { events, stop } = collect(CHANNELS.TRANSACTION_ROLLBACK)
+      try {
+        await tx.rollback()
+        assert.strictEqual(events.length, 1)
+        assert.strictEqual(events[0].aborted, false)
+      } finally {
+        stop()
+      }
+    })
+  })
 })

--- a/test/common/diagnostics.js
+++ b/test/common/diagnostics.js
@@ -1,0 +1,193 @@
+'use strict'
+
+/* globals describe, it */
+
+const assert = require('node:assert')
+const dc = require('node:diagnostics_channel')
+const { CHANNELS, tracingChannels, tracePromise, publish } = require('../../lib/diagnostics')
+
+describe('Diagnostics Channel', () => {
+  describe('CHANNELS', () => {
+    it('exports all TracingChannel names', () => {
+      assert.strictEqual(CHANNELS.TRACE_QUERY, 'mssql:query')
+      assert.strictEqual(CHANNELS.TRACE_BATCH, 'mssql:batch')
+      assert.strictEqual(CHANNELS.TRACE_EXECUTE, 'mssql:execute')
+      assert.strictEqual(CHANNELS.TRACE_BULK, 'mssql:bulk')
+      assert.strictEqual(CHANNELS.TRACE_CONNECT, 'mssql:connect')
+      assert.strictEqual(CHANNELS.TRACE_POOL_ACQUIRE, 'mssql:pool:acquire')
+      assert.strictEqual(CHANNELS.TRACE_PREPARE, 'mssql:prepare')
+      assert.strictEqual(CHANNELS.TRACE_PREPARED_EXECUTE, 'mssql:prepared-execute')
+    })
+
+    it('exports all point-event channel names', () => {
+      assert.strictEqual(CHANNELS.CONNECTION_ACQUIRE, 'mssql:connection:acquire')
+      assert.strictEqual(CHANNELS.CONNECTION_RELEASE, 'mssql:connection:release')
+      assert.strictEqual(CHANNELS.CONNECTION_CREATE, 'mssql:connection:create')
+      assert.strictEqual(CHANNELS.CONNECTION_DESTROY, 'mssql:connection:destroy')
+      assert.strictEqual(CHANNELS.POOL_CLOSE, 'mssql:pool:close')
+      assert.strictEqual(CHANNELS.TRANSACTION_BEGIN, 'mssql:transaction:begin')
+      assert.strictEqual(CHANNELS.TRANSACTION_COMMIT, 'mssql:transaction:commit')
+      assert.strictEqual(CHANNELS.TRANSACTION_ROLLBACK, 'mssql:transaction:rollback')
+      assert.strictEqual(CHANNELS.REQUEST_CANCEL, 'mssql:request:cancel')
+      assert.strictEqual(CHANNELS.PREPARED_STATEMENT_UNPREPARE, 'mssql:prepared-statement:unprepare')
+    })
+
+    it('is frozen', () => {
+      assert.ok(Object.isFrozen(CHANNELS))
+    })
+
+    it('has 18 total channels', () => {
+      assert.strictEqual(Object.keys(CHANNELS).length, 18)
+    })
+  })
+
+  describe('tracingChannels', () => {
+    it('creates TracingChannel instances for all TRACE_ channels', () => {
+      const traceKeys = Object.keys(CHANNELS).filter(k => k.startsWith('TRACE_'))
+      assert.strictEqual(traceKeys.length, 8)
+      for (const key of traceKeys) {
+        const name = CHANNELS[key]
+        const tc = tracingChannels[name]
+        assert.ok(tc, `TracingChannel for ${name} should exist`)
+        // Aggregate hasSubscribers is Node 22+. Sub-channels exist on all
+        // supported versions and are what the helpers fall back to.
+        assert.strictEqual(typeof tc.start.hasSubscribers, 'boolean', `${name}.start should expose hasSubscribers`)
+      }
+    })
+  })
+
+  describe('tracePromise()', () => {
+    it('calls fn directly when no subscribers', async () => {
+      let called = false
+      const result = await tracePromise(CHANNELS.TRACE_QUERY, () => {
+        called = true
+        return Promise.resolve(42)
+      }, { command: 'SELECT 1' })
+      assert.ok(called)
+      assert.strictEqual(result, 42)
+    })
+
+    it('does not allocate context when no subscribers', async () => {
+      let factoryCalled = false
+      await tracePromise(CHANNELS.TRACE_QUERY, () => Promise.resolve(), () => {
+        factoryCalled = true
+        return {}
+      })
+      assert.ok(!factoryCalled, 'context factory should not be called when no subscribers')
+    })
+
+    it('traces through TracingChannel when subscribers exist', async () => {
+      const events = []
+      const tc = dc.tracingChannel(CHANNELS.TRACE_QUERY)
+      const handlers = {
+        start (ctx) { events.push({ event: 'start', command: ctx.command }) },
+        end (ctx) { events.push({ event: 'end' }) },
+        asyncStart (ctx) { events.push({ event: 'asyncStart' }) },
+        asyncEnd (ctx) { events.push({ event: 'asyncEnd' }) },
+        error (ctx) { events.push({ event: 'error' }) }
+      }
+      tc.subscribe(handlers)
+      try {
+        const result = await tracePromise(CHANNELS.TRACE_QUERY, () => {
+          return Promise.resolve('data')
+        }, { command: 'SELECT 1' })
+        assert.strictEqual(result, 'data')
+        assert.ok(events.some(e => e.event === 'start' && e.command === 'SELECT 1'))
+        assert.ok(events.some(e => e.event === 'asyncEnd'))
+      } finally {
+        tc.unsubscribe(handlers)
+      }
+    })
+
+    it('reports errors through TracingChannel error event', async () => {
+      const events = []
+      const tc = dc.tracingChannel(CHANNELS.TRACE_BATCH)
+      const handlers = {
+        start () { events.push('start') },
+        end () { events.push('end') },
+        asyncStart () { events.push('asyncStart') },
+        asyncEnd () { events.push('asyncEnd') },
+        error (ctx) { events.push({ event: 'error', message: ctx.error.message }) }
+      }
+      tc.subscribe(handlers)
+      try {
+        await assert.rejects(
+          () => tracePromise(CHANNELS.TRACE_BATCH, () => {
+            return Promise.reject(new Error('test error'))
+          }, { command: 'BAD SQL' }),
+          { message: 'test error' }
+        )
+        assert.ok(events.some(e => e.event === 'error' && e.message === 'test error'))
+      } finally {
+        tc.unsubscribe(handlers)
+      }
+    })
+
+    it('accepts a factory function for context', async () => {
+      let factoryCalled = false
+      const tc = dc.tracingChannel(CHANNELS.TRACE_EXECUTE)
+      const handlers = {
+        start (ctx) { assert.strictEqual(ctx.procedure, 'sp_test') },
+        end () {},
+        asyncStart () {},
+        asyncEnd () {},
+        error () {}
+      }
+      tc.subscribe(handlers)
+      try {
+        await tracePromise(CHANNELS.TRACE_EXECUTE, () => Promise.resolve(), () => {
+          factoryCalled = true
+          return { procedure: 'sp_test' }
+        })
+        assert.ok(factoryCalled, 'context factory should be called when subscribers exist')
+      } finally {
+        tc.unsubscribe(handlers)
+      }
+    })
+  })
+
+  describe('publish()', () => {
+    it('does nothing when no subscribers', () => {
+      let factoryCalled = false
+      publish(CHANNELS.POOL_CLOSE, () => {
+        factoryCalled = true
+        return { poolId: 1 }
+      })
+      assert.ok(!factoryCalled, 'factory should not be called when no subscribers')
+    })
+
+    it('publishes message when subscribers exist', () => {
+      const messages = []
+      const handler = (msg) => { messages.push(msg) }
+      dc.subscribe(CHANNELS.TRANSACTION_BEGIN, handler)
+      try {
+        publish(CHANNELS.TRANSACTION_BEGIN, () => ({
+          transactionId: 42,
+          isolationLevel: 'READ_COMMITTED',
+          poolId: 1
+        }))
+        assert.strictEqual(messages.length, 1)
+        assert.strictEqual(messages[0].transactionId, 42)
+        assert.strictEqual(messages[0].isolationLevel, 'READ_COMMITTED')
+      } finally {
+        dc.unsubscribe(CHANNELS.TRANSACTION_BEGIN, handler)
+      }
+    })
+  })
+
+  describe('CHANNELS is exported from main module', () => {
+    it('is accessible via require("mssql")', () => {
+      const sql = require('../../')
+      assert.ok(sql.CHANNELS)
+      assert.strictEqual(sql.CHANNELS.TRACE_QUERY, 'mssql:query')
+    })
+  })
+
+  describe('Request._internal flag', () => {
+    it('is false by default', () => {
+      const sql = require('../../')
+      const req = new sql.Request()
+      assert.strictEqual(req._internal, false)
+    })
+  })
+})

--- a/test/common/diagnostics.js
+++ b/test/common/diagnostics.js
@@ -62,7 +62,7 @@ describe('Diagnostics Channel', () => {
       const result = await tracePromise(CHANNELS.TRACE_QUERY, () => {
         called = true
         return Promise.resolve(42)
-      }, { command: 'SELECT 1' })
+      }, () => ({ command: 'SELECT 1' }))
       assert.ok(called)
       assert.strictEqual(result, 42)
     })
@@ -90,7 +90,7 @@ describe('Diagnostics Channel', () => {
       try {
         const result = await tracePromise(CHANNELS.TRACE_QUERY, () => {
           return Promise.resolve('data')
-        }, { command: 'SELECT 1' })
+        }, () => ({ command: 'SELECT 1' }))
         assert.strictEqual(result, 'data')
         assert.ok(events.some(e => e.event === 'start' && e.command === 'SELECT 1'))
         assert.ok(events.some(e => e.event === 'asyncEnd'))
@@ -114,7 +114,7 @@ describe('Diagnostics Channel', () => {
         await assert.rejects(
           () => tracePromise(CHANNELS.TRACE_BATCH, () => {
             return Promise.reject(new Error('test error'))
-          }, { command: 'BAD SQL' }),
+          }, () => ({ command: 'BAD SQL' })),
           { message: 'test error' }
         )
         assert.ok(events.some(e => e.event === 'error' && e.message === 'test error'))

--- a/test/common/diagnostics.js
+++ b/test/common/diagnostics.js
@@ -15,8 +15,8 @@ describe('Diagnostics Channel', () => {
       assert.strictEqual(CHANNELS.TRACE_BULK, 'mssql:bulk')
       assert.strictEqual(CHANNELS.TRACE_CONNECT, 'mssql:connect')
       assert.strictEqual(CHANNELS.TRACE_POOL_ACQUIRE, 'mssql:pool:acquire')
-      assert.strictEqual(CHANNELS.TRACE_PREPARE, 'mssql:prepare')
-      assert.strictEqual(CHANNELS.TRACE_PREPARED_EXECUTE, 'mssql:prepared-execute')
+      assert.strictEqual(CHANNELS.TRACE_PREPARED_STATEMENT_PREPARE, 'mssql:prepared-statement:prepare')
+      assert.strictEqual(CHANNELS.TRACE_PREPARED_STATEMENT_EXECUTE, 'mssql:prepared-statement:execute')
     })
 
     it('exports all point-event channel names', () => {

--- a/test/common/diagnostics.js
+++ b/test/common/diagnostics.js
@@ -163,12 +163,14 @@ describe('Diagnostics Channel', () => {
       try {
         publish(CHANNELS.TRANSACTION_BEGIN, () => ({
           transactionId: 42,
-          isolationLevel: 'READ_COMMITTED',
+          isolationLevel: 0x02,
+          isolationLevelName: 'READ_COMMITTED',
           poolId: 1
         }))
         assert.strictEqual(messages.length, 1)
         assert.strictEqual(messages[0].transactionId, 42)
-        assert.strictEqual(messages[0].isolationLevel, 'READ_COMMITTED')
+        assert.strictEqual(messages[0].isolationLevel, 0x02)
+        assert.strictEqual(messages[0].isolationLevelName, 'READ_COMMITTED')
       } finally {
         dc.unsubscribe(CHANNELS.TRANSACTION_BEGIN, handler)
       }

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -8,6 +8,8 @@ const udt = require('../../lib/udt')
 const BasePool = require('../../lib/base/connection-pool')
 const ConnectionPool = require('../../lib/tedious/connection-pool')
 
+require('./diagnostics')
+
 describe('Unit', () => {
   it('table', done => {
     let t = new sql.Table('MyTable')


### PR DESCRIPTION
## Summary

Adds `diagnostics_channel` integration to `node-mssql`, enabling observability tooling (OpenTelemetry, custom metrics, logging) to subscribe to library events with near-zero overhead when not in use.

Inspired by [node-redis#3195](https://github.com/redis/node-redis/pull/3195).

### TracingChannels (8)

Async operation tracing via `dc.tracingChannel()` — provides start/end/asyncStart/asyncEnd/error lifecycle events for both the promise and callback APIs:

- **`mssql:query`** — `request.query()`
- **`mssql:batch`** — `request.batch()`
- **`mssql:execute`** — `request.execute()`
- **`mssql:bulk`** — `request.bulk()`
- **`mssql:connect`** — `pool.connect()`
- **`mssql:pool:acquire`** — connection acquisition from pool (measures wait/saturation)
- **`mssql:prepared-statement:prepare`** — `ps.prepare()`
- **`mssql:prepared-statement:execute`** — `ps.execute()`

### Point-event channels (10)

Single events at state transitions:

- `mssql:connection:acquire` / `release`
- `mssql:connection:create` / `destroy`
- `mssql:pool:close`
- `mssql:transaction:begin` / `commit` / `rollback`
- `mssql:request:cancel`
- `mssql:prepared-statement:unprepare`

### Design decisions

- **Node.js `>=18.19.0`** minimum — required for `dc.tracingChannel()`; includes polyfill for `TracingChannel.hasSubscribers` (added in Node 22)
- **Both promise and callback APIs** are instrumented via `tracePromise()` and `traceCallback()` respectively
- **Context factories** — all trace contexts and point-event messages use factory callbacks, so there is zero object allocation when no subscribers are active
- **Zero overhead** when no subscribers — `hasSubscribers` check gates all work
- **Internal request suppression** — framework-generated requests (`sp_prepare`, `sp_execute`, `sp_unprepare`) are marked `_internal = true` and excluded from tracing
- **No parameter values** in trace contexts — only parameter names; SQL text is included but documented with redaction guidance
- **XACT_ABORT auto-rollback** tracked in tedious driver via `transaction:rollback` with `aborted: true`
- **`CHANNELS`** exported as a frozen object of string constants for minimal semver surface
- **`getPoolId()`** hoisted to `lib/utils.js` as a shared utility
- **Pool close** publishes on both success and failure paths, with optional `error` in the payload
- **Transaction events** include both numeric `isolationLevel` and human-readable `isolationLevelName`
- **Prepared-statement channels** namespaced under `mssql:prepared-statement:*` for consistency

### Breaking changes

- Minimum Node.js version bumped from `>=18` to `>=18.19.0`

### Files changed (14)

| File | Change |
|---|---|
| `lib/diagnostics.js` | **New** — core infrastructure (CHANNELS, tracingChannels, tracePromise, traceCallback, publish) |
| `lib/base/request.js` | Instrument query/batch/execute/bulk (promise + callback), cancel event, `_internal` flag |
| `lib/base/connection-pool.js` | Instrument connect, acquire (TracingChannel), release, close events |
| `lib/base/transaction.js` | Publish begin/commit/rollback events with isolation level |
| `lib/base/prepared-statement.js` | Instrument prepare/execute (TracingChannel), unprepare event, mark internal requests |
| `lib/tedious/connection-pool.js` | Publish connection:create / connection:destroy |
| `lib/msnodesqlv8/connection-pool.js` | Publish connection:create / connection:destroy |
| `lib/tedious/transaction.js` | Publish transaction:rollback on XACT_ABORT auto-abort |
| `lib/base/index.js` | Export CHANNELS |
| `lib/utils.js` | Add shared `getPoolId()` helper |
| `package.json` | Bump engines.node to `>=18.19.0` |
| `README.md` | Diagnostics Channel documentation section |
| `test/common/diagnostics.js` | **New** — 27 unit tests |
| `test/common/unit.js` | Include diagnostics test file |

### Test coverage

74 total unit tests passing (47 existing + 27 new diagnostics tests):
- Channel constant exports and structure
- TracingChannel instance creation
- `tracePromise` / `traceCallback` zero-overhead when no subscribers
- Context factory lazy evaluation
- TracingChannel lifecycle events (start, asyncEnd, error)
- `traceCallback` lifecycle events
- `publish` zero-overhead and message delivery
- End-to-end instrumentation verification (Request, Transaction, PreparedStatement)
- CHANNELS accessibility via `require("mssql")`
- `_internal` flag default value