### PR TITLE
fix: preserve originalError on EABORT TransactionError

### DIFF
--- a/lib/base/transaction.js
+++ b/lib/base/transaction.js
@@ -152,6 +152,7 @@ class Transaction extends EventEmitter {
     }
 
     this._aborted = false
+    this._abortReason = null
     this._rollbackRequested = false
     if (isolationLevel) {
       if (Object.keys(ISOLATION_LEVEL).some(key => {
@@ -200,6 +201,22 @@ class Transaction extends EventEmitter {
   }
 
   /**
+   * Creates a TransactionError for an aborted transaction, preserving the
+   * original abort reason (if any) as `originalError`.
+   *
+   * @private
+   * @return {TransactionError}
+   */
+
+  _createAbortError () {
+    const err = new TransactionError('Transaction has been aborted.', 'EABORT')
+    if (this._abortReason) {
+      Object.defineProperty(err, 'originalError', { enumerable: true, value: this._abortReason })
+    }
+    return err
+  }
+
+  /**
    * @private
    * @param {basicCallback} [callback]
    * @return {Transaction}
@@ -207,7 +224,7 @@ class Transaction extends EventEmitter {
 
   _commit (callback) {
     if (this._aborted) {
-      return setImmediate(callback, new TransactionError('Transaction has been aborted.', 'EABORT'))
+      return setImmediate(callback, this._createAbortError())
     }
 
     if (!this._acquiredConnection) {
@@ -279,7 +296,7 @@ class Transaction extends EventEmitter {
 
   _rollback (callback) {
     if (this._aborted) {
-      return setImmediate(callback, new TransactionError('Transaction has been aborted.', 'EABORT'))
+      return setImmediate(callback, this._createAbortError())
     }
 
     if (!this._acquiredConnection) {

--- a/lib/tedious/request.js
+++ b/lib/tedious/request.js
@@ -300,6 +300,10 @@ class Request extends BaseRequest {
           } catch (e) {
             // noop
           }
+          if (this.parent._aborted) {
+            const reason = err || errors[errors.length - 1]
+            if (reason) this.parent._abortReason = reason
+          }
           callback(err, ...args)
         }
         if (err) return callbackWithRelease(err)
@@ -501,6 +505,10 @@ class Request extends BaseRequest {
             }
 
             this.parent.release(connection)
+            if (this.parent._aborted) {
+              const reason = error || errors[errors.length - 1]
+              if (reason) this.parent._abortReason = reason
+            }
             hasReturned = true
 
             if (error) {
@@ -865,6 +873,10 @@ class Request extends BaseRequest {
             }
 
             this.parent.release(connection)
+            if (this.parent._aborted) {
+              const reason = error || errors[errors.length - 1]
+              if (reason) this.parent._abortReason = reason
+            }
             hasReturned = true
 
             if (error) {

--- a/lib/tedious/transaction.js
+++ b/lib/tedious/transaction.js
@@ -23,6 +23,7 @@ class Transaction extends BaseTransaction {
         this._acquiredConnection = null
         this._acquiredConfig = null
         this._aborted = true
+        this._abortReason = this._abortReason || new Error('Transaction was rolled back by the server')
 
         publish(CHANNELS.TRANSACTION_ROLLBACK, () => ({
           transactionId: IDS.get(this),

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -1422,4 +1422,63 @@ describe('connection string auth - tedious', () => {
       req.on('error', () => done())
     })
   })
+
+  describe('Transaction EABORT originalError', () => {
+    const BaseTransaction = require('../../lib/base/transaction')
+
+    it('commit on aborted transaction returns EABORT with originalError', (done) => {
+      const tx = new BaseTransaction(null)
+      tx._aborted = true
+      const reason = new Error('deadlock victim')
+      reason.code = 'EREQUEST'
+      tx._abortReason = reason
+
+      tx.commit((err) => {
+        assert.ok(err)
+        assert.strictEqual(err.code, 'EABORT')
+        assert.strictEqual(err.message, 'Transaction has been aborted.')
+        assert.strictEqual(err.originalError, reason)
+        assert.strictEqual(err.originalError.message, 'deadlock victim')
+        done()
+      })
+    })
+
+    it('rollback on aborted transaction returns EABORT with originalError', (done) => {
+      const tx = new BaseTransaction(null)
+      tx._aborted = true
+      const reason = new Error('constraint violation')
+      tx._abortReason = reason
+
+      tx.rollback((err) => {
+        assert.ok(err)
+        assert.strictEqual(err.code, 'EABORT')
+        assert.strictEqual(err.message, 'Transaction has been aborted.')
+        assert.strictEqual(err.originalError, reason)
+        done()
+      })
+    })
+
+    it('commit on aborted transaction without _abortReason omits originalError', (done) => {
+      const tx = new BaseTransaction(null)
+      tx._aborted = true
+
+      tx.commit((err) => {
+        assert.ok(err)
+        assert.strictEqual(err.code, 'EABORT')
+        assert.strictEqual(err.originalError, undefined)
+        done()
+      })
+    })
+
+    it('_abortReason is reset on begin', (done) => {
+      const tx = new BaseTransaction(null)
+      tx._abortReason = new Error('old reason')
+      tx._begin(undefined, (err) => {
+        assert.ifError(err)
+        assert.strictEqual(tx._abortReason, null)
+        assert.strictEqual(tx._aborted, false)
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Problem

When a transaction is aborted by the server (e.g. due to `XACT_ABORT` or a deadlock), subsequent `commit()` or `rollback()` calls return a `TransactionError` with code `EABORT`. However, `originalError` was always `undefined` on these errors because the error was constructed with a string message rather than an `Error` object.

This made it difficult for consumers to understand *why* the transaction was aborted without correlating errors manually.

Closes #1716

## Solution

1. **Capture the actual request error** — When a request completes with an error and the transaction has been aborted, the error is stored as `_abortReason` on the transaction. This is done in the tedious request completion handlers (`_query`, `_execute`, `_bulk`).

2. **Generic fallback** — The tedious `_abort` handler (fired by the `rollbackTransaction` event) sets a generic `"Transaction was rolled back by the server"` fallback reason for edge cases where the specific error cannot be captured (e.g. connection-level errors).

3. **Attach as `originalError`** — A new `_createAbortError()` helper on the base `Transaction` class constructs the EABORT `TransactionError` and attaches `_abortReason` as `originalError` using `Object.defineProperty` (matching the pattern used elsewhere in `MSSQLError`).

## Changes

- `lib/base/transaction.js` — Added `_abortReason` tracking, `_createAbortError()` helper, reset on `_begin()`
- `lib/tedious/transaction.js` — Generic fallback `_abortReason` in `_abort` handler
- `lib/tedious/request.js` — Capture actual request error as abort reason in `_query`, `_execute`, `_bulk` completion paths
- `test/common/unit.js` — 4 new unit tests for EABORT `originalError` behavior

## Example

```js
const tx = pool.transaction()
await tx.begin()
try {
  // This query triggers XACT_ABORT
  await tx.request().query("INSERT INTO ...")
} catch (requestErr) {
  // requestErr is the original SQL error
}
try {
  await tx.rollback()
} catch (abortErr) {
  // abortErr.code === "EABORT"
  // abortErr.originalError === requestErr  ← previously undefined
}
```