### PR TITLE
fix: pass dataLength to getMssqlType in valueCorrection

### DIFF
--- a/lib/tedious/request.js
+++ b/lib/tedious/request.js
@@ -176,7 +176,7 @@ const createColumns = function (metadata, arrayRowMode) {
 }
 
 const valueCorrection = function (value, metadata) {
-  const type = getMssqlType(metadata.type)
+  const type = getMssqlType(metadata.type, metadata.dataLength)
   if (valueHandler.has(type)) {
     return valueHandler.get(type)(value)
   } else if ((metadata.type === tds.TYPES.UDT) && (value != null)) {

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -162,6 +162,21 @@ module.exports = (sql, driver) => {
         done()
       }).catch(done)
     },
+    'value handler for IntN types uses correct type' (done) {
+      let bigIntCalls = 0
+      let intCalls = 0
+      let tinyIntCalls = 0
+      sql.valueHandler.set(sql.TYPES.BigInt, (value) => { bigIntCalls++; return value })
+      sql.valueHandler.set(sql.TYPES.Int, (value) => { intCalls++; return value })
+      sql.valueHandler.set(sql.TYPES.TinyInt, (value) => { tinyIntCalls++; return value })
+      sql.query('SELECT CAST(1 AS bigint) AS big, CAST(2 AS int) AS med, CAST(3 AS tinyint) AS tiny').then((result) => {
+        assert.strictEqual(result.recordset.length, 1)
+        assert.strictEqual(bigIntCalls, 1, 'BigInt handler should be called once')
+        assert.strictEqual(intCalls, 1, 'Int handler should be called once')
+        assert.strictEqual(tinyIntCalls, 1, 'TinyInt handler should be called once')
+        done()
+      }).catch(done)
+    },
     'bigint inputs' (done) {
       const req = new TestRequest()
       req.input('bigintparam', BigInt('4294967294'))

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -46,6 +46,7 @@ describe('msnodesqlv8', function () {
 
     it('config validation', done => TESTS['config validation'](done))
     it('value handler', done => TESTS['value handler'](done))
+    it('value handler for IntN types uses correct type', done => TESTS['value handler for IntN types uses correct type'](done))
     it('bigint inputs', done => TESTS['bigint inputs'](done))
     it('stored procedure (exec)', done => TESTS['stored procedure']('execute', done))
     it('stored procedure (batch)', done => TESTS['stored procedure']('batch', done))

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -53,6 +53,7 @@ describe('tedious', () => {
 
     it('config validation', done => TESTS['config validation'](done))
     it('value handler', done => TESTS['value handler'](done))
+    it('value handler for IntN types uses correct type', done => TESTS['value handler for IntN types uses correct type'](done))
     it('bigint inputs', done => TESTS['bigint inputs'](done))
     it('stored procedure (exec)', done => TESTS['stored procedure']('execute', done))
     it('stored procedure (batch)', done => TESTS['stored procedure']('batch', done))


### PR DESCRIPTION
## Problem

`valueCorrection()` calls `getMssqlType(metadata.type)` without passing the `length` argument. The `getMssqlType` function uses `length` to disambiguate nullable N-types (IntN, FloatN, MoneyN, DateTimeN) — without it, they always resolve to the smallest variant:

| N-Type | Expected (with length) | Actual (without length) |
|--------|----------------------|----------------------|
| IntN (len=8) | BigInt | TinyInt |
| IntN (len=4) | Int | TinyInt |
| IntN (len=2) | SmallInt | TinyInt |
| FloatN (len=8) | Float | Real |
| MoneyN (len=8) | Money | SmallMoney |
| DateTimeN (len=8) | DateTime | SmallDateTime |

This means `valueHandler` entries registered for `BigInt`, `Int`, `SmallInt`, `Float`, `Money`, or `DateTime` are never invoked — only the smallest variant handler fires.

Note: column metadata types (via `createColumns`) are **not** affected — that call site already passes `column.dataLength` correctly.

Closes #1853

## Fix

One-liner: pass `metadata.dataLength` as the second argument to `getMssqlType()` in `valueCorrection()`.

## Tests

Added an integration test that registers separate value handlers for `BigInt`, `Int`, and `TinyInt`, then queries all three types. Without the fix, only the `TinyInt` handler fires; with the fix, each handler fires exactly once.