### PR TITLE
fix: parse boolean connection string options correctly

### DIFF
--- a/lib/base/connection-pool.js
+++ b/lib/base/connection-pool.js
@@ -10,6 +10,14 @@ const shared = require('../shared')
 const { MSSQLError } = require('../error')
 const { CHANNELS, tracePromise, traceCallback, publish } = require('../diagnostics')
 
+const NODE_MSSQL_SCHEMA = {
+  ...MSSQL_SCHEMA,
+  useutc: { type: 'boolean' },
+  stream: { type: 'boolean' },
+  parsejson: { type: 'boolean' },
+  'request timeout': { type: 'number' }
+}
+
 /**
  * Class ConnectionPool.
  *
@@ -124,7 +132,7 @@ class ConnectionPool extends EventEmitter {
 
   static _parseConnectionString (connectionString) {
     const result = parse(connectionString)
-    const parsed = result.toSchema(MSSQL_SCHEMA)
+    const parsed = result.toSchema(NODE_MSSQL_SCHEMA)
     // Include non-standard keys (client id, tenant id, token, msi endpoint, msi secret)
     // that are used for authentication but not part of the MSSQL schema
     for (const [key, value] of result) {

--- a/test/common/unit.js
+++ b/test/common/unit.js
@@ -736,6 +736,43 @@ describe('connection string parser', () => {
   })
 })
 
+describe('connection string boolean options', () => {
+  it('parses useUTC=False as false', () => {
+    const config = BasePool._parseConnectionString('Server=localhost;useUTC=False')
+    assert.strictEqual(config.options.useUTC, false)
+  })
+
+  it('parses useUTC=True as true', () => {
+    const config = BasePool._parseConnectionString('Server=localhost;useUTC=True')
+    assert.strictEqual(config.options.useUTC, true)
+  })
+
+  it('parses useUTC=false as false', () => {
+    const config = BasePool._parseConnectionString('Server=localhost;useUTC=false')
+    assert.strictEqual(config.options.useUTC, false)
+  })
+
+  it('parses stream=False as false', () => {
+    const config = BasePool._parseConnectionString('Server=localhost;stream=False')
+    assert.strictEqual(config.stream, false)
+  })
+
+  it('parses stream=True as true', () => {
+    const config = BasePool._parseConnectionString('Server=localhost;stream=True')
+    assert.strictEqual(config.stream, true)
+  })
+
+  it('parses parseJSON=False as false', () => {
+    const config = BasePool._parseConnectionString('Server=localhost;parseJSON=False')
+    assert.strictEqual(config.parseJSON, false)
+  })
+
+  it('parses parseJSON=True as true', () => {
+    const config = BasePool._parseConnectionString('Server=localhost;parseJSON=True')
+    assert.strictEqual(config.parseJSON, true)
+  })
+})
+
 describe('connection string auth - base', () => {
   it('parses basic login', () => {
     const config = BasePool._parseConnectionString('Server=database.test.com;Database=test;User Id=test;Password=admin')


### PR DESCRIPTION
## Problem

`useUTC=False` in a connection string is incorrectly parsed as `true`.

The `useutc`, `stream`, and `parsejson` keys are not part of the upstream `MSSQL_SCHEMA`, so `toSchema()` does not include them in its output. They are then added back from the raw parse result as **strings** (e.g. `"False"`). The existing `!!value` coercion converts any non-empty string to `true`, making it impossible to disable these options via connection strings.

## Fix

Extend `MSSQL_SCHEMA` with the node-mssql-specific keys (`useutc`, `stream`, `parsejson` as `boolean`, `request timeout` as `number`) so that `toSchema()` handles the type conversion automatically — the same way it already handles `encrypt`, `trustservercertificate`, etc.

## Tests

Added 7 tests covering `True`/`False`/`false` variations for `useUTC`, `stream`, and `parseJSON`.

Closes #1860