### PR TITLE
fix: prevent TypeError in batch with output parameters when sql errors

### DIFF
--- a/lib/tedious/request.js
+++ b/lib/tedious/request.js
@@ -477,7 +477,7 @@ class Request extends BaseRequest {
 
           // process batch outputs
           if (batchHasOutput) {
-            if (!this.stream) batchLastRow = recordsets.pop()[0]
+            if (!this.stream) batchLastRow = recordsets.pop()?.[0]
 
             for (const name in batchLastRow) {
               const value = batchLastRow[name]

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -644,6 +644,22 @@ module.exports = (sql, driver) => {
       }).catch(done)
     },
 
+    'batch with output parameters and sql error' (done) {
+      const req = new TestRequest()
+      req.output('out', sql.Int)
+      req.batch('select * from notexistingtable').then(() => {
+        done(new Error('expected batch to reject with sql error'))
+      }).catch(err => {
+        try {
+          assert.ok(err instanceof sql.RequestError, `expected RequestError, got ${err && err.constructor.name}: ${err && err.message}`)
+          assert.strictEqual(err.code, 'EREQUEST')
+          done()
+        } catch (assertionError) {
+          done(assertionError)
+        }
+      })
+    },
+
     'create procedure batch' (done) {
       let req = new TestRequest()
       req.batch('create procedure #temporary as select 1 as num').then(result => {

--- a/test/msnodesqlv8/msnodesqlv8.js
+++ b/test/msnodesqlv8/msnodesqlv8.js
@@ -74,6 +74,7 @@ describe('msnodesqlv8', function () {
     it('query with pipe and back pressure', (done) => TESTS['query with pipe and back pressure'](done))
     it('batch', done => TESTS.batch(done))
     it('batch (stream)', done => TESTS.batch(done, true))
+    it('batch with output parameters and sql error', done => TESTS['batch with output parameters and sql error'](done))
     it('create procedure batch', done => TESTS['create procedure batch'](done))
     it('prepared statement', done => TESTS['prepared statement'](done))
     it('prepared statement that fails to prepare throws', done => TESTS['prepared statement that fails to prepare throws'](done))

--- a/test/tedious/tedious.js
+++ b/test/tedious/tedious.js
@@ -81,6 +81,7 @@ describe('tedious', () => {
     it('query with pipe and back pressure', (done) => TESTS['query with pipe and back pressure'](done))
     it('query with duplicate output column names', done => TESTS['query with duplicate output column names'](done))
     it('batch', done => TESTS.batch(done))
+    it('batch with output parameters and sql error', done => TESTS['batch with output parameters and sql error'](done))
     it('create procedure batch', done => TESTS['create procedure batch'](done))
     it('prepared statement', done => TESTS['prepared statement'](done))
     it('prepared statement that fails to prepare throws', done => TESTS['prepared statement that fails to prepare throws'](done))


### PR DESCRIPTION
## Summary
- Guard `recordsets.pop()[0]` in `lib/tedious/request.js` with optional chaining so a SQL error in a batch with declared output parameters doesn't crash before the request callback fires.
- Without the guard, when the batch fails before the appended `select 1 as [___return___], ...` trailer can run (e.g. a compile error, or a runtime error under `SET XACT_ABORT ON`), `recordsets` is empty, `recordsets.pop()` is `undefined`, and `[0]` throws synchronously inside the tedious request callback. The user callback never fires, the request promise never settles, and the connection is never released.
- Added an integration test (`'batch with output parameters and sql error'`) that reproduces the original crash and asserts the SQL error rejects the promise as a `RequestError` / `EREQUEST`.

## Test plan
- [x] `npm run test-tedious -- --grep 'batch with output parameters and sql error'` passes (was crashing with `TypeError: Cannot read properties of undefined (reading '0') at request.js:480` on master)
- [x] All adjacent batch / output / stored-procedure tests still pass
- [x] `npm run lint` clean

Fixes #1863

🤖 Generated with [Claude Code](https://claude.com/claude-code)