### PR TITLE
ci: disable fail-fast on the windows test matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -113,6 +113,7 @@ jobs:
     env:
       MSSQL_PASSWORD: 'yourStrong(!)Password'
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2022, windows-2025]
         node: [18.x, 20.x, 22.x, 24.x]


### PR DESCRIPTION
## Problem

The `test-windows` job in `.github/workflows/nodejs.yml` did not set `fail-fast`, so GitHub Actions defaulted to `fail-fast: true`.

With `fail-fast: true`, when **any** single matrix combination fails — frequently due to a transient error during the multi-minute SQL Server setup phase — GitHub Actions cancels **every other in-progress and queued job** in that matrix. Those cancelled jobs would otherwise have passed, and recovering requires re-running the whole matrix and re-doing the expensive setup for all combinations.

## Fix

Add `fail-fast: false` under the `strategy:` key of the `test-windows` job (alongside the existing `matrix:`). This lets the rest of the windows matrix keep running even when one combination fails, so a single transient failure no longer wipes out otherwise-passing siblings.

The matrix dimensions are unchanged.

```diff
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2022, windows-2025]
```

## Why `test-linux` keeps fail-fast enabled

`test-linux` intentionally keeps the default `fail-fast: true`. Those jobs bootstrap much faster (SQL Server via the services container rather than a full Windows install), and because `test-windows` has `needs: [..., test-linux]`, a linux failure should stop the run **before** the slower, more expensive windows matrix starts — rather than wasting time on windows when linux has already shown the change is broken.

## Note

> Commit history: this branch contains an `amend!` fixup on top of the original commit; it will collapse into a single clean commit at autosquash time before merge.