### PR TITLE
feat: test msnodesqlv8 against v2-v5 across supported Node versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -145,17 +145,35 @@ jobs:
         run: npm run test-tedious
       - name: Run cli tests
         run: npm run test-cli
-      - name: Install msnodesqlv8
-        if: ${{ matrix.node != '22.x' && matrix.node != '24.x' }}
+      # msnodesqlv8 is exercised across its supported major versions. Each major
+      # is gated to the Node versions it ships prebuilt win32-x64 binaries for —
+      # a combo without a prebuild falls back to a node-gyp source build, which is
+      # brittle on the GitHub Windows images (e.g. the VS 2026 rollout on
+      # windows-2025 that node-gyp cannot detect). Coverage:
+      #   v2: Node 18    v3: Node 18-20    v4: Node 18-24    v5: Node 20-24
+      - name: Install msnodesqlv8 v2
+        if: ${{ matrix.node == '18.x' }}
         run: npm install --no-save msnodesqlv8@^2
-      - name: Run msnodesqlv8 tests
-        if: ${{ matrix.node != '22.x' && matrix.node != '24.x' }}
+      - name: Run msnodesqlv8 v2 tests
+        if: ${{ matrix.node == '18.x' }}
         run: npm run test-msnodesqlv8
-      - name: Install msnodesqlv8
-        if: ${{ matrix.node == '22.x' || matrix.node == '24.x' }}
+      - name: Install msnodesqlv8 v3
+        if: ${{ matrix.node == '18.x' || matrix.node == '20.x' }}
+        run: npm install --no-save msnodesqlv8@^3
+      - name: Run msnodesqlv8 v3 tests
+        if: ${{ matrix.node == '18.x' || matrix.node == '20.x' }}
+        run: npm run test-msnodesqlv8
+      - name: Install msnodesqlv8 v4
+        if: ${{ matrix.node == '18.x' || matrix.node == '20.x' || matrix.node == '22.x' || matrix.node == '24.x' }}
         run: npm install --no-save msnodesqlv8@^4
-      - name: Run msnodesqlv8 tests
-        if: ${{ matrix.node == '22.x' && matrix.node == '24.x' }}
+      - name: Run msnodesqlv8 v4 tests
+        if: ${{ matrix.node == '18.x' || matrix.node == '20.x' || matrix.node == '22.x' || matrix.node == '24.x' }}
+        run: npm run test-msnodesqlv8
+      - name: Install msnodesqlv8 v5
+        if: ${{ matrix.node == '20.x' || matrix.node == '22.x' || matrix.node == '24.x' }}
+        run: npm install --no-save msnodesqlv8@^5
+      - name: Run msnodesqlv8 v5 tests
+        if: ${{ matrix.node == '20.x' || matrix.node == '22.x' || matrix.node == '24.x' }}
         run: npm run test-msnodesqlv8
   release:
     name: Release

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Supported TDS drivers:
 
 - [Tedious][tedious-url] (pure JavaScript - Windows/macOS/Linux, default)
-- [MSNodeSQLv8][msnodesqlv8-url] (Microsoft / Contributors Node V8 Driver for Node.js for SQL Server, v2 native - Windows or Linux/macOS 64 bits only)
+- [MSNodeSQLv8][msnodesqlv8-url] (Microsoft / Contributors Node V8 Driver for Node.js for SQL Server, v2-v5 native - Windows or Linux/macOS 64 bits only)
 
 ## Installation
 


### PR DESCRIPTION
## Why

PRs were failing on the Windows CI matrix — specifically **Node 20 on `windows-2025`** (every SQL Server version) — while installing `msnodesqlv8@^2`, which fell back to a `node-gyp` source build that couldn't find a Visual Studio toolchain:

```
gyp ERR! find VS unknown version "undefined" found at "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
```

The cause is environmental, not in node-mssql: GitHub's `windows-2025` label is being routed to the `windows-2025-vs2026` image (Visual Studio 2026, internal version 18), and the bundled `node-gyp` can't detect VS 2026 — see [actions/runner-images#14004](https://github.com/actions/runner-images/issues/14004) and [nodejs/node-gyp#3250](https://github.com/nodejs/node-gyp/issues/3250).

It only hit Node 20 because that was the one matrix cell that compiled from source: `msnodesqlv8@^2` ships no prebuilt `win32-x64` binary for Node 20 (ABI 115), whereas Node 18 (v2 prebuild) and Node 22/24 (v4 prebuilds) loaded prebuilt binaries and never invoked `node-gyp`.

## What

Gate each `msnodesqlv8` major to the Node versions it actually ships a prebuilt `win32-x64` binary for, so CI never compiles from source — which makes the VS toolchain on the runner image irrelevant:

| Node | v2 | v3 | v4 | v5 |
|------|:--:|:--:|:--:|:--:|
| 18 | ✅ | ✅ | ✅ | — |
| 20 | — | ✅ | ✅ | ✅ |
| 22 | — | — | ✅ | ✅ |
| 24 | — | — | ✅ | ✅ |

This fixes the failure **and** broadens driver coverage from `{v2, v4}` to `{v2, v3, v4, v5}`. The README driver line is updated to `v2-v5`.

It also removes a pre-existing always-false condition (`node == '22.x' && node == '24.x'`) that silently skipped the `msnodesqlv8` tests on Node 22/24 entirely.

## Notes

- **v5 is the N-API rewrite.** Its cells (Node 20/22/24) are newly exercised and could surface real adapter incompatibilities. `fail-fast: false` (already on the windows matrix) means any such failure reports independently rather than cancelling siblings.
- Linux `msnodesqlv8` testing remains disabled (separate, pre-existing segfault) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
