### PR TITLE
ci: pin msnodesqlv8 v5 to 5.2.1 on Node 20

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -162,6 +162,13 @@ jobs:
       # brittle on the GitHub Windows images (e.g. the VS 2026 rollout on
       # windows-2025 that node-gyp cannot detect). Coverage:
       #   v2: Node 18    v3: Node 18-20    v4: Node 18-24    v5: Node 20-24
+      #
+      # v5 is split: msnodesqlv8 5.2.2 dropped the Node 20 (ABI 115) win32-x64
+      # prebuild, so `@^5` (5.2.3+) is gated to Node 22-24 and Node 20 is pinned
+      # to 5.2.1 — the last v5 release that ships one. Upstream now builds
+      # prebuilds for Node 22/24/26 only, so a floating `@^5` will not regain a
+      # Node 20 prebuild; leaving Node 20 on `@^5` source-builds via node-gyp,
+      # which is slow on windows-2022 and fails outright on windows-2025.
       - name: Install msnodesqlv8 v2
         if: ${{ matrix.node == '18.x' }}
         run: npm install --no-save msnodesqlv8@^2
@@ -180,11 +187,17 @@ jobs:
       - name: Run msnodesqlv8 v4 tests
         if: ${{ matrix.node == '18.x' || matrix.node == '20.x' || matrix.node == '22.x' || matrix.node == '24.x' }}
         run: npm run test-msnodesqlv8
+      - name: Install msnodesqlv8 v5 (Node 20, pinned)
+        if: ${{ matrix.node == '20.x' }}
+        run: npm install --no-save msnodesqlv8@5.2.1
+      - name: Run msnodesqlv8 v5 tests (Node 20, pinned)
+        if: ${{ matrix.node == '20.x' }}
+        run: npm run test-msnodesqlv8
       - name: Install msnodesqlv8 v5
-        if: ${{ matrix.node == '20.x' || matrix.node == '22.x' || matrix.node == '24.x' }}
+        if: ${{ matrix.node == '22.x' || matrix.node == '24.x' }}
         run: npm install --no-save msnodesqlv8@^5
       - name: Run msnodesqlv8 v5 tests
-        if: ${{ matrix.node == '20.x' || matrix.node == '22.x' || matrix.node == '24.x' }}
+        if: ${{ matrix.node == '22.x' || matrix.node == '24.x' }}
         run: npm run test-msnodesqlv8
   release:
     name: Release


### PR DESCRIPTION
Fixes #1882.

## The failure

msnodesqlv8 **5.2.2 dropped the Node 20 (ABI 115) win32-x64 prebuild**. Since `@^5` resolves to 5.2.3, `npm install --no-save msnodesqlv8@^5` on Node 20 falls through its `prebuild-install || node-gyp rebuild` install script to a source build:

```
prebuild-install warn install No prebuilt binaries found (target=20.20.2 runtime=node arch=x64 libc= platform=win32)
gyp ERR! find VS unknown version "undefined" found at "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! stack Error: Could not find any Visual Studio installation to use
```

node-gyp 10.1.0 (bundled with Node 20's npm) can't parse the Visual Studio 2026 install that `windows-2025` now ships, so all four `windows-2025, 20.x` cells fail at *Install msnodesqlv8 v5* on every run, regardless of the changes under test. `windows-2022, 20.x` survives only because VS 2022 is present — it silently spends ~3 minutes compiling from source.

Published win32-x64 prebuild ABIs, per the upstream GitHub releases:

| version | win32-x64 node ABIs |
|---|---|
| 5.2.1 | **115**, 127, 131, 137, 141, 147 |
| 5.2.2 | 127, 137, 147 |
| 5.2.3 | 127, 137, 147 |

## The fix

Upstream's `prebuild.yml` matrix is `node: [22, 24, 26]` — Node 20 is past EOL and the toolchain dropped it — so a floating `@^5` will not regain a Node 20 binary. Rather than dropping Node 20 from the v5 gate entirely (which would delete all v5-on-Node-20 coverage, currently green on the four `windows-2022, 20.x` cells), the v5 steps are split:

- `@^5` gated to Node 22-24
- a Node 20 step pinned to `5.2.1`, the last v5 release shipping an ABI 115 prebuild

Node 20 remains supported by this package (`engines.node: ">=18.19.0"`) and by msnodesqlv8 5.2.3 itself (`engines.node: ">=18"`), so keeping the combination exercised seemed worth a pinned version.

## Verification

Cross-checked every gated combination against the published release assets — all ten now resolve to a prebuild, so no cell falls back to node-gyp:

| step | resolves to | Node | ABI | prebuild |
|---|---|---|---|---|
| v2 | 2.7.0 | 18 | 108 | yes |
| v3 | 3.1.0 | 18, 20 | 108, 115 | yes |
| v4 | 4.5.0 | 18, 20, 22, 24 | 108, 115, 127, 137 | yes |
| v5 (pinned) | 5.2.1 | 20 | 115 | yes |
| v5 | 5.2.3 | 22, 24 | 127, 137 | yes |

Side benefit: `windows-2022, 20.x` loses its ~3-minute source build too.

Note that master also carries four failing **Dependabot Updates** runs (`tar`, `js-yaml`, `undici`, `brace-expansion`). Those are unrelated to this change and are tracked separately — all four are dev-only transitives with no impact on published-package consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)